### PR TITLE
Add USB CDC support with UART fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ pip install pyserial
 cd ~/projects/keep-esp32
 source ~/esp/esp-idf/export.sh
 idf.py build
-idf.py -p /dev/ttyUSB0 flash monitor
+idf.py -p /dev/ttyACM0 flash monitor
 ```
 
 ## Quick Start
@@ -69,11 +69,11 @@ idf.py -p /dev/ttyUSB0 flash monitor
 # Add keep to PATH for convenience
 export PATH="$PATH:~/projects/keep/target/release"
 
-# Test device connection
-keep frost hardware ping --device /dev/ttyUSB0
+# Test device connection (USB CDC)
+keep frost hardware ping --device /dev/ttyACM0
 
 # List shares stored on device
-keep frost hardware list --device /dev/ttyUSB0
+keep frost hardware list --device /dev/ttyACM0
 ```
 
 ### Import a Share (from local keep storage)
@@ -88,7 +88,7 @@ keep frost generate --threshold 2 --shares 3 --name mygroup
 keep frost list
 
 # Export share #1 to hardware device
-keep frost hardware import --device /dev/ttyUSB0 --group mygroup --share 1
+keep frost hardware import --device /dev/ttyACM0 --group mygroup --share 1
 ```
 
 ### Sign with Hardware (threshold signing)
@@ -101,7 +101,7 @@ keep frost network sign \
   --group mygroup \
   --message $(echo -n "hello" | sha256sum | cut -d' ' -f1) \
   --relay wss://nos.lol \
-  --hardware /dev/ttyUSB0
+  --hardware /dev/ttyACM0
 ```
 
 For single-device testing, see [test/hardware/](test/hardware/) for scripts that simulate multiple signers.
@@ -141,7 +141,7 @@ keep frost network dkg \
   --participants 3 \
   --index 1 \
   --relay wss://nos.lol \
-  --hardware /dev/ttyUSB0
+  --hardware /dev/ttyACM0
 
 # Participant 2 (on second device)
 keep frost network dkg \
@@ -150,7 +150,7 @@ keep frost network dkg \
   --participants 3 \
   --index 2 \
   --relay wss://nos.lol \
-  --hardware /dev/ttyUSB0
+  --hardware /dev/ttyACM0
 
 # Participant 3 (on third device)
 keep frost network dkg \
@@ -159,7 +159,7 @@ keep frost network dkg \
   --participants 3 \
   --index 3 \
   --relay wss://nos.lol \
-  --hardware /dev/ttyUSB0
+  --hardware /dev/ttyACM0
 ```
 
 All participants must start within 5 minutes. On success, each device stores its share and displays the group public key.

--- a/main/serial.c
+++ b/main/serial.c
@@ -2,6 +2,7 @@
 #include "freertos/FreeRTOS.h"
 #include "esp_log.h"
 #include "driver/uart.h"
+#include "driver/usb_serial_jtag.h"
 #include <string.h>
 #include <stdio.h>
 
@@ -11,8 +12,21 @@
 static const char *TAG = "serial";
 static char rx_buf[RX_BUF_SIZE];
 static size_t rx_pos = 0;
+static bool use_usb_cdc = false;
 
 int serial_init(void) {
+    usb_serial_jtag_driver_config_t usb_cfg = {
+        .rx_buffer_size = RX_BUF_SIZE,
+        .tx_buffer_size = RX_BUF_SIZE,
+    };
+
+    if (usb_serial_jtag_driver_install(&usb_cfg) == ESP_OK) {
+        use_usb_cdc = true;
+        ESP_LOGI(TAG, "USB CDC initialized");
+        return 0;
+    }
+
+    ESP_LOGW(TAG, "USB CDC failed, falling back to UART");
     esp_err_t err = uart_driver_install(UART_NUM, RX_BUF_SIZE, 0, 0, NULL, 0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "UART driver install failed: %s (%d)", esp_err_to_name(err), err);
@@ -24,7 +38,17 @@ int serial_init(void) {
 
 int serial_read_line(char *buf, size_t len) {
     uint8_t c;
-    while (uart_read_bytes(UART_NUM, &c, 1, pdMS_TO_TICKS(10)) > 0) {
+    int bytes_read;
+
+    while (1) {
+        if (use_usb_cdc) {
+            bytes_read = usb_serial_jtag_read_bytes(&c, 1, pdMS_TO_TICKS(10));
+        } else {
+            bytes_read = uart_read_bytes(UART_NUM, &c, 1, pdMS_TO_TICKS(10));
+        }
+
+        if (bytes_read <= 0) break;
+
         if (c == '\n' || c == '\r') {
             if (rx_pos > 0) {
                 size_t copy_len = rx_pos < len - 1 ? rx_pos : len - 1;
@@ -42,7 +66,32 @@ int serial_read_line(char *buf, size_t len) {
 
 int serial_write_line(const char *buf) {
     size_t len = strlen(buf);
-    uart_write_bytes(UART_NUM, buf, len);
-    uart_write_bytes(UART_NUM, "\n", 1);
-    return (int)len;
+    int written, nl_written;
+
+    if (use_usb_cdc) {
+        written = usb_serial_jtag_write_bytes(buf, len, pdMS_TO_TICKS(100));
+        if (written < 0) {
+            return -1;
+        }
+        if ((size_t)written != len) {
+            return -1;
+        }
+        nl_written = usb_serial_jtag_write_bytes("\n", 1, pdMS_TO_TICKS(100));
+        if (nl_written != 1) {
+            return -1;
+        }
+    } else {
+        written = uart_write_bytes(UART_NUM, buf, len);
+        if (written < 0) {
+            return -1;
+        }
+        if ((size_t)written != len) {
+            return -1;
+        }
+        nl_written = uart_write_bytes(UART_NUM, "\n", 1);
+        if (nl_written != 1) {
+            return -1;
+        }
+    }
+    return (int)(len + 1);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all serial port command examples in README, changing device references from /dev/ttyUSB0 to /dev/ttyACM0 across build, flash, test, import, signing, and DKG workflows.

* **New Features**
  * Added USB CDC support for device communication with intelligent fallback to UART connection when USB CDC is unavailable, ensuring compatibility across different connection types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->