### PR TITLE
Fix remaining code duplication in hex and random utils

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -1,7 +1,8 @@
 idf_component_register(
     SRCS "main.c" "protocol.c" "serial.c" "storage.c" "frost_signer.c" "frost.c" "session.c"
          "nostr_frost.c" "nostr_frost_sign.c" "nostr_frost_dkg_events.c" "nostr_frost_nip46.c"
-         "frost_crypto_ops.c" "frost_coordinator.c" "frost_dkg.c" "psbt.c" "policy.c" "hex_utils.c"
+         "frost_crypto_ops.c" "frost_coordinator.c" "frost_dkg.c" "psbt.c" "policy.c"
+         "hex_utils.c" "random_utils.c"
     INCLUDE_DIRS "."
     REQUIRES esp_partition driver esp_driver_usb_serial_jtag esp_driver_uart esp_driver_gpio mbedtls crypto_asm libnostr-c noscrypt
     PRIV_REQUIRES secp256k1-frost espressif__cjson espressif__esp_websocket_client libwally-core

--- a/main/frost_coordinator.c
+++ b/main/frost_coordinator.c
@@ -2,13 +2,15 @@
 #include "nostr_frost.h"
 #include "crypto_asm.h"
 #include "hex_utils.h"
+#include "random_utils.h"
 #include "cJSON.h"
 #include <noscrypt.h>
+#include <string.h>
+#include <stdlib.h>
 
 #ifdef ESP_PLATFORM
 #include "esp_log.h"
 #include "esp_websocket_client.h"
-#include "esp_random.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #else
@@ -16,30 +18,7 @@
 #define ESP_LOGI(tag, fmt, ...) printf("[%s] " fmt "\n", tag, ##__VA_ARGS__)
 #define ESP_LOGE(tag, fmt, ...) printf("[%s] ERROR: " fmt "\n", tag, ##__VA_ARGS__)
 #define ESP_LOGW(tag, fmt, ...) printf("[%s] WARN: " fmt "\n", tag, ##__VA_ARGS__)
-
-static int secure_random_fill(uint8_t *buf, size_t len) {
-    FILE *fp = fopen("/dev/urandom", "r");
-    if (!fp) {
-        fprintf(stderr, "FATAL: Cannot open /dev/urandom\n");
-        return -1;
-    }
-    size_t total = 0;
-    while (total < len) {
-        size_t n = fread(buf + total, 1, len - total, fp);
-        if (n == 0) {
-            fclose(fp);
-            fprintf(stderr, "FATAL: Failed to read from /dev/urandom\n");
-            return -1;
-        }
-        total += n;
-    }
-    fclose(fp);
-    return 0;
-}
 #endif
-
-#include <string.h>
-#include <stdlib.h>
 
 #define TAG "frost_coord"
 
@@ -190,15 +169,14 @@ int frost_coordinator_init(const uint8_t privkey[32]) {
     }
 
     uint8_t entropy[NC_CONTEXT_ENTROPY_SIZE];
-#ifdef ESP_PLATFORM
-    esp_fill_random(entropy, sizeof(entropy));
-#else
     if (secure_random_fill(entropy, sizeof(entropy)) != 0) {
-        ESP_LOGE(TAG, "Failed to get entropy from /dev/urandom");
+        ESP_LOGE(TAG, "Failed to get secure random");
         free(g_ctx.nc_ctx);
+#ifdef ESP_PLATFORM
+        vSemaphoreDelete(g_ctx.mutex);
+#endif
         return -3;
     }
-#endif
 
     if (NCInitContext(g_ctx.nc_ctx, entropy) != NC_SUCCESS) {
         ESP_LOGE(TAG, "Failed to init noscrypt context");

--- a/main/frost_crypto_ops.c
+++ b/main/frost_crypto_ops.c
@@ -1,4 +1,5 @@
 #include "nostr_frost.h"
+#include "random_utils.h"
 #include "crypto_asm.h"
 #include <secp256k1.h>
 #include <secp256k1_frost.h>
@@ -7,26 +8,12 @@
 #include <stdlib.h>
 
 #ifdef ESP_PLATFORM
-#include "esp_random.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 static SemaphoreHandle_t g_secp_mutex = NULL;
 #else
-#include <stdio.h>
 #include <pthread.h>
 static pthread_mutex_t g_secp_mutex = PTHREAD_MUTEX_INITIALIZER;
-static int secure_random_fill(uint8_t *buf, size_t len) {
-    FILE *fp = fopen("/dev/urandom", "r");
-    if (!fp) return -1;
-    size_t total = 0;
-    while (total < len) {
-        size_t n = fread(buf + total, 1, len - total, fp);
-        if (n == 0) { fclose(fp); return -1; }
-        total += n;
-    }
-    fclose(fp);
-    return 0;
-}
 #endif
 
 static secp256k1_context *g_secp_ctx = NULL;
@@ -237,10 +224,6 @@ int frost_sign_partial(const frost_group_t *group,
     memcpy(kp->secret, our_share, 32);
 
     uint8_t binding_seed[32], hiding_seed[32];
-#ifdef ESP_PLATFORM
-    esp_fill_random(binding_seed, 32);
-    esp_fill_random(hiding_seed, 32);
-#else
     if (secure_random_fill(binding_seed, 32) != 0 || secure_random_fill(hiding_seed, 32) != 0) {
         secure_memzero(kp->secret, 32);
         secp256k1_frost_keypair_destroy(kp);
@@ -248,7 +231,6 @@ int frost_sign_partial(const frost_group_t *group,
         strncpy(response->rejection_reason, "Failed to get secure random", sizeof(response->rejection_reason) - 1);
         return -4;
     }
-#endif
 
     secp256k1_frost_nonce *nonce = secp256k1_frost_nonce_create(ctx, kp, binding_seed, hiding_seed);
     secure_memzero(binding_seed, 32);

--- a/main/hex_utils.c
+++ b/main/hex_utils.c
@@ -2,7 +2,7 @@
 #include <string.h>
 #include <stdio.h>
 
-int hex_digit(char c) {
+static int hex_digit(char c) {
     if (c >= '0' && c <= '9') return c - '0';
     if (c >= 'a' && c <= 'f') return c - 'a' + 10;
     if (c >= 'A' && c <= 'F') return c - 'A' + 10;

--- a/main/hex_utils.h
+++ b/main/hex_utils.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <stddef.h>
 
-int hex_digit(char c);
 int hex_to_bytes(const char *hex, uint8_t *out, size_t out_len);
 void bytes_to_hex(const uint8_t *bytes, size_t len, char *out);
 

--- a/main/policy.c
+++ b/main/policy.c
@@ -1,4 +1,5 @@
 #include "policy.h"
+#include "hex_utils.h"
 #include "esp_partition.h"
 #include "esp_log.h"
 #include "crypto_asm.h"
@@ -145,32 +146,6 @@ int policy_check_hash(const policy_bundle_t *bundle, const uint8_t expected_hash
         return POLICY_ERR_HASH_MISMATCH;
     }
     return 0;
-}
-
-static int hex_digit(char c) {
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_to_bytes(const char *hex, uint8_t *out, size_t out_len) {
-    size_t hex_len = strlen(hex);
-    if (hex_len % 2 != 0 || hex_len / 2 > out_len) return -1;
-    for (size_t i = 0; i < hex_len / 2; i++) {
-        int hi = hex_digit(hex[2 * i]);
-        int lo = hex_digit(hex[2 * i + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (uint8_t)((hi << 4) | lo);
-    }
-    return (int)(hex_len / 2);
-}
-
-static void bytes_to_hex(const uint8_t *bytes, size_t len, char *out) {
-    for (size_t i = 0; i < len; i++) {
-        sprintf(out + 2 * i, "%02x", bytes[i]);
-    }
-    out[len * 2] = '\0';
 }
 
 void policy_handle_update(const rpc_request_t *req, rpc_response_t *resp) {

--- a/main/random_utils.c
+++ b/main/random_utils.c
@@ -1,0 +1,27 @@
+#include "random_utils.h"
+
+#ifdef ESP_PLATFORM
+#include "esp_random.h"
+
+int secure_random_fill(uint8_t *buf, size_t len) {
+    esp_fill_random(buf, len);
+    return 0;
+}
+
+#else
+#include <stdio.h>
+
+int secure_random_fill(uint8_t *buf, size_t len) {
+    FILE *fp = fopen("/dev/urandom", "r");
+    if (!fp) return -1;
+    size_t total = 0;
+    while (total < len) {
+        size_t n = fread(buf + total, 1, len - total, fp);
+        if (n == 0) { fclose(fp); return -1; }
+        total += n;
+    }
+    fclose(fp);
+    return 0;
+}
+
+#endif

--- a/main/random_utils.h
+++ b/main/random_utils.h
@@ -1,0 +1,9 @@
+#ifndef RANDOM_UTILS_H
+#define RANDOM_UTILS_H
+
+#include <stdint.h>
+#include <stddef.h>
+
+int secure_random_fill(uint8_t *buf, size_t len);
+
+#endif

--- a/main/storage.c
+++ b/main/storage.c
@@ -1,9 +1,9 @@
 #include "storage.h"
+#include "hex_utils.h"
 #include "esp_partition.h"
 #include "esp_log.h"
 #include "crypto_asm.h"
 #include <string.h>
-#include <stdio.h>
 #include <ctype.h>
 
 #define TAG "storage"
@@ -24,26 +24,6 @@ static bool initialized = false;
 static uint8_t sector_buf[SECTOR_SIZE];
 static share_slot_t work_slot;
 
-static int hex_digit(char c) {
-    if (c >= '0' && c <= '9') return c - '0';
-    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
-    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
-    return -1;
-}
-
-static int hex_to_bytes(const char *hex, unsigned char *out, size_t out_len) {
-    size_t hex_len = strlen(hex);
-    if (hex_len % 2 != 0 || hex_len / 2 > out_len) return -1;
-
-    for (size_t i = 0; i < hex_len / 2; i++) {
-        int hi = hex_digit(hex[2 * i]);
-        int lo = hex_digit(hex[2 * i + 1]);
-        if (hi < 0 || lo < 0) return -1;
-        out[i] = (unsigned char)((hi << 4) | lo);
-    }
-    return hex_len / 2;
-}
-
 static int validate_group_name(const char *group) {
     size_t len = strnlen(group, STORAGE_GROUP_LEN + 1);
     if (len == 0 || len > STORAGE_GROUP_LEN) return 0;
@@ -52,13 +32,6 @@ static int validate_group_name(const char *group) {
         if (!isalnum(c) && c != '_' && c != '-') return 0;
     }
     return 1;
-}
-
-static void bytes_to_hex(const unsigned char *bytes, size_t len, char *out) {
-    for (size_t i = 0; i < len; i++) {
-        sprintf(out + 2 * i, "%02x", bytes[i]);
-    }
-    out[len * 2] = '\0';
 }
 
 int storage_init(void) {


### PR DESCRIPTION
- Make hex_digit static (internal only)
- Remove duplicate hex utils from storage.c and policy.c
- Create shared random_utils for secure_random_fill
- Remove duplicate random functions from frost_crypto_ops.c and frost_coordinator.c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated random number generation utilities into a dedicated module with cross-platform support.
  * Extracted and centralized hex conversion utilities previously duplicated across multiple files.
  * Improved code organization by removing duplicate implementations and establishing clear utility module boundaries.

* **Chores**
  * Updated build configuration to reflect new module structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->