### PR TITLE
Replace atoi() with strtol() for input validation

### DIFF
--- a/fuzz/fuzz_dkg.c
+++ b/fuzz/fuzz_dkg.c
@@ -32,11 +32,13 @@ static int parse_dkg_round1_data(const char *dkg_data, dkg_round1_data_t *out) {
         return -1;
     }
 
-    out->num_coefficients = (uint8_t)atoi(num_coeff_str + 18);
-    if (out->num_coefficients > MAX_THRESHOLD) {
+    char *endptr;
+    long num_coeff_tmp = strtol(num_coeff_str + 18, &endptr, 10);
+    if (endptr == num_coeff_str + 18 || num_coeff_tmp <= 0 || num_coeff_tmp > MAX_THRESHOLD) {
         free(data);
         return -1;
     }
+    out->num_coefficients = (uint8_t)num_coeff_tmp;
 
     char *coeffs_start = coeffs_str + 26;
     char *coeffs_end = strchr(coeffs_start, '"');

--- a/main/frost_dkg.c
+++ b/main/frost_dkg.c
@@ -205,12 +205,14 @@ void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
         return;
     }
 
-    peer->num_coefficients = (uint8_t)atoi(num_coeff_str + 18);
-    if (peer->num_coefficients > MAX_THRESHOLD) {
+    char *endptr;
+    long num_coeff_tmp = strtol(num_coeff_str + 18, &endptr, 10);
+    if (endptr == num_coeff_str + 18 || num_coeff_tmp <= 0 || num_coeff_tmp > MAX_THRESHOLD) {
         free(data);
-        PROTOCOL_ERROR(resp, req->id, -1, "Too many coefficients");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid num_coefficients");
         return;
     }
+    peer->num_coefficients = (uint8_t)num_coeff_tmp;
 
     char *coeffs_start = coeffs_str + 26;
     char *coeffs_end = strchr(coeffs_start, '"');

--- a/main/nostr_frost.c
+++ b/main/nostr_frost.c
@@ -151,9 +151,17 @@ static int parse_tags(cJSON *tags, frost_group_t *group) {
         if (strcmp(name, "d") == 0) {
             hex_to_bytes(val, group->group_id, GROUP_ID_LEN);
         } else if (strcmp(name, "threshold") == 0) {
-            group->threshold = (uint8_t)atoi(val);
+            char *endptr;
+            long tmp = strtol(val, &endptr, 10);
+            if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                group->threshold = (uint8_t)tmp;
+            }
         } else if (strcmp(name, "participants") == 0) {
-            group->participant_count = (uint8_t)atoi(val);
+            char *endptr;
+            long tmp = strtol(val, &endptr, 10);
+            if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                group->participant_count = (uint8_t)tmp;
+            }
         } else if (strcmp(name, "relay") == 0) {
             if (group->relay_count < MAX_RELAYS) {
                 strncpy(group->relays[group->relay_count], val, RELAY_URL_LEN - 1);
@@ -184,7 +192,11 @@ static int parse_tags(cJSON *tags, frost_group_t *group) {
                 if (tag_size >= 4) {
                     cJSON *idx = cJSON_GetArrayItem(tag, 3);
                     if (cJSON_IsString(idx)) {
-                        p->index = (uint8_t)atoi(idx->valuestring);
+                        char *endptr;
+                        long tmp = strtol(idx->valuestring, &endptr, 10);
+                        if (endptr != idx->valuestring && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                            p->index = (uint8_t)tmp;
+                        }
                     }
                 }
                 if (p->index == 0) {

--- a/main/nostr_frost_dkg_events.c
+++ b/main/nostr_frost_dkg_events.c
@@ -121,7 +121,11 @@ int frost_parse_dkg_round1_event(const char *event_json,
                     }
                 }
             } else if (strcmp(name, "participant_index") == 0) {
-                round1->participant_index = (uint8_t)atoi(val);
+                char *endptr;
+                long tmp = strtol(val, &endptr, 10);
+                if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                    round1->participant_index = (uint8_t)tmp;
+                }
             }
         }
     }
@@ -288,9 +292,17 @@ int frost_parse_dkg_round2_event(const char *event_json,
                     }
                 }
             } else if (strcmp(name, "participant_index") == 0) {
-                round2->sender_index = (uint8_t)atoi(val);
+                char *endptr;
+                long tmp = strtol(val, &endptr, 10);
+                if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                    round2->sender_index = (uint8_t)tmp;
+                }
             } else if (strcmp(name, "recipient_index") == 0) {
-                round2->recipient_index = (uint8_t)atoi(val);
+                char *endptr;
+                long tmp = strtol(val, &endptr, 10);
+                if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                    round2->recipient_index = (uint8_t)tmp;
+                }
             }
         }
     }

--- a/main/nostr_frost_sign.c
+++ b/main/nostr_frost_sign.c
@@ -332,7 +332,11 @@ int frost_parse_sign_response(const char *event_json,
             if (strcmp(name, "request_id") == 0) {
                 hex_to_bytes(val, response->request_id, 32);
             } else if (strcmp(name, "participant_index") == 0) {
-                response->participant_index = (uint8_t)atoi(val);
+                char *endptr;
+                long tmp = strtol(val, &endptr, 10);
+                if (endptr != val && *endptr == '\0' && tmp > 0 && tmp <= UINT8_MAX) {
+                    response->participant_index = (uint8_t)tmp;
+                }
             } else if (strcmp(name, "status") == 0) {
                 if (strcmp(val, "signed") == 0) {
                     response->status = FROST_SIGN_STATUS_SIGNED;


### PR DESCRIPTION
## Summary
- Replace 8 atoi() calls with strtol() across 4 files
- Add proper validation for parsed integer values
- Reject invalid input instead of silently returning 0

## Test plan
- [ ] Build passes
- [ ] DKG round1/round2 parsing works correctly
- [ ] Sign response parsing works correctly
- [ ] Invalid input is properly rejected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation of numeric inputs to reject malformed or out-of-range values.
  * Prevented invalid participant/threshold/index values from being accepted or applied.
  * Improved error handling and reporting for invalid numeric parameters, reducing unexpected behavior and crashes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->