### PR TITLE
Add buffer size parameter to bytes_to_hex()

### DIFF
--- a/main/frost_coordinator.c
+++ b/main/frost_coordinator.c
@@ -326,7 +326,7 @@ int frost_coordinator_subscribe(const char *subscription_id) {
     if (!g_initialized || !g_ctx.has_group) return -1;
 
     char pubkey_hex[65];
-    bytes_to_hex(g_ctx.pubkey, 32, pubkey_hex);
+    bytes_to_hex(g_ctx.pubkey, 32, pubkey_hex, sizeof(pubkey_hex));
 
     char filter[512];
     snprintf(filter, sizeof(filter),

--- a/main/frost_dkg.c
+++ b/main/frost_dkg.c
@@ -138,7 +138,7 @@ void dkg_round1(const rpc_request_t *req, rpc_response_t *resp) {
     char coeffs_hex[MAX_THRESHOLD * 129];
     size_t offset = 0;
     for (uint8_t i = 0; i < g_session.our_round1.num_coefficients && i < MAX_THRESHOLD; i++) {
-        bytes_to_hex(g_session.our_round1.coefficient_commitments[i], 64, coeffs_hex + offset);
+        bytes_to_hex(g_session.our_round1.coefficient_commitments[i], 64, coeffs_hex + offset, sizeof(coeffs_hex) - offset);
         offset += 128;
         if (i < g_session.our_round1.num_coefficients - 1) {
             coeffs_hex[offset++] = ',';
@@ -147,8 +147,8 @@ void dkg_round1(const rpc_request_t *req, rpc_response_t *resp) {
     coeffs_hex[offset] = '\0';
 
     char zkp_r_hex[129], zkp_z_hex[65];
-    bytes_to_hex(g_session.our_round1.zkp_r, 64, zkp_r_hex);
-    bytes_to_hex(g_session.our_round1.zkp_z, 32, zkp_z_hex);
+    bytes_to_hex(g_session.our_round1.zkp_r, 64, zkp_r_hex, sizeof(zkp_r_hex));
+    bytes_to_hex(g_session.our_round1.zkp_z, 32, zkp_z_hex, sizeof(zkp_z_hex));
 
     snprintf(result, sizeof(result),
              "{\"participant_index\":%d,\"num_coefficients\":%d,"
@@ -275,7 +275,7 @@ void dkg_round2(const rpc_request_t *req, rpc_response_t *resp) {
         }
 
         char share_hex[65];
-        bytes_to_hex(g_session.secret_shares[i], 32, share_hex);
+        bytes_to_hex(g_session.secret_shares[i], 32, share_hex, sizeof(share_hex));
 
         if (!first) {
             offset += snprintf(result + offset, sizeof(result) - offset, ",");
@@ -367,7 +367,7 @@ void dkg_finalize(const rpc_request_t *req, rpc_response_t *resp) {
     }
 
     char share_hex[65];
-    bytes_to_hex(final_share, 32, share_hex);
+    bytes_to_hex(final_share, 32, share_hex, sizeof(share_hex));
 
     if (storage_save_share(g_session.group, share_hex) != 0) {
         secure_memzero(final_share, sizeof(final_share));
@@ -377,7 +377,7 @@ void dkg_finalize(const rpc_request_t *req, rpc_response_t *resp) {
     }
 
     char pubkey_hex[67];
-    bytes_to_hex(group_pubkey, 33, pubkey_hex);
+    bytes_to_hex(group_pubkey, 33, pubkey_hex, sizeof(pubkey_hex));
 
     secure_memzero(final_share, sizeof(final_share));
     secure_memzero(share_hex, sizeof(share_hex));

--- a/main/frost_signer.c
+++ b/main/frost_signer.c
@@ -206,7 +206,7 @@ void frost_get_pubkey(const char *group, rpc_response_t *resp) {
     }
 
     char pubkey_hex[67];
-    bytes_to_hex(state.group_pubkey, sizeof(state.group_pubkey), pubkey_hex);
+    bytes_to_hex(state.group_pubkey, sizeof(state.group_pubkey), pubkey_hex, sizeof(pubkey_hex));
 
     char result[128];
     snprintf(result, sizeof(result), "{\"pubkey\":\"%s\",\"index\":%d}",
@@ -224,7 +224,7 @@ void frost_get_share_info(const char *group, rpc_response_t *resp) {
     }
 
     char pubkey_hex[67];
-    bytes_to_hex(state.group_pubkey, sizeof(state.group_pubkey), pubkey_hex);
+    bytes_to_hex(state.group_pubkey, sizeof(state.group_pubkey), pubkey_hex, sizeof(pubkey_hex));
 
     char result[192];
     snprintf(result, sizeof(result),
@@ -307,7 +307,7 @@ void frost_commit(const char *group, const char *session_id_hex, const char *mes
     }
 
     char commitment_hex[COMMITMENT_HEX_LEN + 1];
-    bytes_to_hex(commitment, commitment_len, commitment_hex);
+    bytes_to_hex(commitment, commitment_len, commitment_hex, sizeof(commitment_hex));
 
     char result[512];
     snprintf(result, sizeof(result),
@@ -396,7 +396,7 @@ void frost_sign(const char *group, const char *session_id_hex, const char *commi
     }
 
     char sig_share_hex[73];
-    bytes_to_hex(sig_share, sig_share_len, sig_share_hex);
+    bytes_to_hex(sig_share, sig_share_len, sig_share_hex, sizeof(sig_share_hex));
 
     char result[192];
     snprintf(result, sizeof(result),
@@ -504,7 +504,7 @@ void frost_aggregate_shares(const char *session_id_hex, rpc_response_t *resp) {
     }
 
     char sig_hex[SIGNATURE_LEN * 2 + 1];
-    bytes_to_hex(signature, SIGNATURE_LEN, sig_hex);
+    bytes_to_hex(signature, SIGNATURE_LEN, sig_hex, sizeof(sig_hex));
 
     char result[192];
     snprintf(result, sizeof(result), "{\"signature\":\"%s\"}", sig_hex);

--- a/main/hex_utils.h
+++ b/main/hex_utils.h
@@ -9,8 +9,11 @@ static inline int hex_to_bytes(const char *hex, uint8_t *out, size_t out_len) {
     return nostr_hex_decode(hex, out, out_len);
 }
 
-static inline void bytes_to_hex(const uint8_t *bytes, size_t len, char *out) {
+static inline int bytes_to_hex(const uint8_t *bytes, size_t len, char *out, size_t out_size) {
+    size_t required = len * 2 + 1;
+    if (out_size < required) return -1;
     nostr_hex_encode(bytes, len, out);
+    return 0;
 }
 
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -14,6 +14,7 @@
 #include "psbt.h"
 #include "policy.h"
 #include "random_utils.h"
+#include "hex_utils.h"
 
 #define TAG "main"
 #define VERSION "0.1.2"
@@ -166,10 +167,7 @@ static void handle_bitcoin_sign(const rpc_request_t *req, rpc_response_t *resp) 
     }
 
     char hex[65];
-    for (int i = 0; i < 32; i++) {
-        snprintf(hex + i * 2, 3, "%02x", sighash[i]);
-    }
-    hex[64] = '\0';
+    bytes_to_hex(sighash, 32, hex, sizeof(hex));
 
     char result[128];
     snprintf(result, sizeof(result), "{\"input_idx\":%zu,\"sighash\":\"%s\"}", req->input_idx, hex);

--- a/main/nostr_frost.c
+++ b/main/nostr_frost.c
@@ -51,7 +51,7 @@ int sign_event_json(cJSON *event, const uint8_t privkey[32]) {
     }
 
     char pubkey_hex[65];
-    bytes_to_hex(pub.data, 32, pubkey_hex);
+    bytes_to_hex(pub.data, 32, pubkey_hex, sizeof(pubkey_hex));
     cJSON_DeleteItemFromObject(event, "pubkey");
     cJSON_AddStringToObject(event, "pubkey", pubkey_hex);
 
@@ -66,7 +66,7 @@ int sign_event_json(cJSON *event, const uint8_t privkey[32]) {
     }
 
     char id_hex[65];
-    bytes_to_hex(id, 32, id_hex);
+    bytes_to_hex(id, 32, id_hex, sizeof(id_hex));
     cJSON_DeleteItemFromObject(event, "id");
     cJSON_AddStringToObject(event, "id", id_hex);
 
@@ -87,12 +87,12 @@ int sign_event_json(cJSON *event, const uint8_t privkey[32]) {
     secure_wipe(&priv, sizeof(priv));
 
     char sig_hex[129];
-    bytes_to_hex(ev->sig, 64, sig_hex);
+    bytes_to_hex(ev->sig, 64, sig_hex, sizeof(sig_hex));
     cJSON_DeleteItemFromObject(event, "sig");
     cJSON_AddStringToObject(event, "sig", sig_hex);
 
     char new_id_hex[65];
-    bytes_to_hex(ev->id, 32, new_id_hex);
+    bytes_to_hex(ev->id, 32, new_id_hex, sizeof(new_id_hex));
     cJSON_DeleteItemFromObject(event, "id");
     cJSON_AddStringToObject(event, "id", new_id_hex);
 
@@ -235,13 +235,13 @@ int frost_create_group_event(const frost_group_t *group,
     cJSON_AddNumberToObject(root, "kind", FROST_KIND_GROUP);
 
     char pubkey_hex[65];
-    bytes_to_hex(group->coordinator_npub, 32, pubkey_hex);
+    bytes_to_hex(group->coordinator_npub, 32, pubkey_hex, sizeof(pubkey_hex));
     cJSON_AddStringToObject(root, "pubkey", pubkey_hex);
 
     cJSON *tags = cJSON_AddArrayToObject(root, "tags");
 
     char id_hex[65];
-    bytes_to_hex(group->group_id, 32, id_hex);
+    bytes_to_hex(group->group_id, 32, id_hex, sizeof(id_hex));
     cJSON *d_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(d_tag, cJSON_CreateString("d"));
     cJSON_AddItemToArray(d_tag, cJSON_CreateString(id_hex));
@@ -266,7 +266,7 @@ int frost_create_group_event(const frost_group_t *group,
         cJSON *ptag = cJSON_CreateArray();
         cJSON_AddItemToArray(ptag, cJSON_CreateString("p"));
         char npub_hex[65];
-        bytes_to_hex(part->npub, 32, npub_hex);
+        bytes_to_hex(part->npub, 32, npub_hex, sizeof(npub_hex));
         cJSON_AddItemToArray(ptag, cJSON_CreateString(npub_hex));
         cJSON_AddItemToArray(ptag, cJSON_CreateString(part->relay_hint));
         char idx_str[8];
@@ -286,7 +286,7 @@ int frost_create_group_event(const frost_group_t *group,
         cJSON *ntag = cJSON_CreateArray();
         cJSON_AddItemToArray(ntag, cJSON_CreateString("notification_pubkey"));
         char npk_hex[65];
-        bytes_to_hex(group->notification_pubkey, 32, npk_hex);
+        bytes_to_hex(group->notification_pubkey, 32, npk_hex, sizeof(npk_hex));
         cJSON_AddItemToArray(ntag, cJSON_CreateString(npk_hex));
         cJSON_AddItemToArray(tags, ntag);
     }

--- a/main/nostr_frost_dkg_events.c
+++ b/main/nostr_frost_dkg_events.c
@@ -18,7 +18,7 @@ int frost_create_dkg_round1_event(const frost_group_t *group,
     cJSON *tags = cJSON_AddArrayToObject(root, "tags");
 
     char gid_hex[65];
-    bytes_to_hex(round1->group_id, 32, gid_hex);
+    bytes_to_hex(round1->group_id, 32, gid_hex, sizeof(gid_hex));
     cJSON *e_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(e_tag, cJSON_CreateString("e"));
     cJSON_AddItemToArray(e_tag, cJSON_CreateString(gid_hex));
@@ -30,7 +30,7 @@ int frost_create_dkg_round1_event(const frost_group_t *group,
         cJSON *p_tag = cJSON_CreateArray();
         cJSON_AddItemToArray(p_tag, cJSON_CreateString("p"));
         char npub_hex[65];
-        bytes_to_hex(group->participants[i].npub, 32, npub_hex);
+        bytes_to_hex(group->participants[i].npub, 32, npub_hex, sizeof(npub_hex));
         cJSON_AddItemToArray(p_tag, cJSON_CreateString(npub_hex));
         cJSON_AddItemToArray(tags, p_tag);
     }
@@ -47,14 +47,14 @@ int frost_create_dkg_round1_event(const frost_group_t *group,
     cJSON *coeffs = cJSON_AddArrayToObject(content_obj, "coefficient_commitments");
     for (uint8_t i = 0; i < round1->num_coefficients; i++) {
         char coeff_hex[129];
-        bytes_to_hex(round1->coefficient_commitments[i], 64, coeff_hex);
+        bytes_to_hex(round1->coefficient_commitments[i], 64, coeff_hex, sizeof(coeff_hex));
         cJSON_AddItemToArray(coeffs, cJSON_CreateString(coeff_hex));
     }
     char zkp_r_hex[129];
-    bytes_to_hex(round1->zkp_r, 64, zkp_r_hex);
+    bytes_to_hex(round1->zkp_r, 64, zkp_r_hex, sizeof(zkp_r_hex));
     cJSON_AddStringToObject(content_obj, "zkp_r", zkp_r_hex);
     char zkp_z_hex[65];
-    bytes_to_hex(round1->zkp_z, 32, zkp_z_hex);
+    bytes_to_hex(round1->zkp_z, 32, zkp_z_hex, sizeof(zkp_z_hex));
     cJSON_AddStringToObject(content_obj, "zkp_z", zkp_z_hex);
 
     char *content_str = cJSON_PrintUnformatted(content_obj);
@@ -185,7 +185,7 @@ int frost_create_dkg_round2_event(const frost_group_t *group,
     cJSON *tags = cJSON_AddArrayToObject(root, "tags");
 
     char gid_hex[65];
-    bytes_to_hex(round2->group_id, 32, gid_hex);
+    bytes_to_hex(round2->group_id, 32, gid_hex, sizeof(gid_hex));
     cJSON *e_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(e_tag, cJSON_CreateString("e"));
     cJSON_AddItemToArray(e_tag, cJSON_CreateString(gid_hex));
@@ -196,7 +196,7 @@ int frost_create_dkg_round2_event(const frost_group_t *group,
     cJSON *p_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(p_tag, cJSON_CreateString("p"));
     char recip_hex[65];
-    bytes_to_hex(recipient_pubkey, 32, recip_hex);
+    bytes_to_hex(recipient_pubkey, 32, recip_hex, sizeof(recip_hex));
     cJSON_AddItemToArray(p_tag, cJSON_CreateString(recip_hex));
     cJSON_AddItemToArray(tags, p_tag);
 
@@ -216,7 +216,7 @@ int frost_create_dkg_round2_event(const frost_group_t *group,
 
     cJSON *content_obj = cJSON_CreateObject();
     char share_hex[97];
-    bytes_to_hex(round2->encrypted_share, 48, share_hex);
+    bytes_to_hex(round2->encrypted_share, 48, share_hex, sizeof(share_hex));
     cJSON_AddStringToObject(content_obj, "share", share_hex);
     cJSON_AddNumberToObject(content_obj, "sender_index", round2->sender_index);
     cJSON_AddNumberToObject(content_obj, "recipient_index", round2->recipient_index);

--- a/main/nostr_frost_nip46.c
+++ b/main/nostr_frost_nip46.c
@@ -79,7 +79,7 @@ int frost_create_nip46_response(const nip46_response_t *response,
     cJSON *p_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(p_tag, cJSON_CreateString("p"));
     char recip_hex[65];
-    bytes_to_hex(recipient_pubkey, 32, recip_hex);
+    bytes_to_hex(recipient_pubkey, 32, recip_hex, sizeof(recip_hex));
     cJSON_AddItemToArray(p_tag, cJSON_CreateString(recip_hex));
     cJSON_AddItemToArray(tags, p_tag);
 

--- a/main/nostr_frost_sign.c
+++ b/main/nostr_frost_sign.c
@@ -121,7 +121,7 @@ int frost_create_sign_request(const frost_group_t *group,
     cJSON *tags = cJSON_AddArrayToObject(root, "tags");
 
     char gid_hex[65];
-    bytes_to_hex(request->group_id, 32, gid_hex);
+    bytes_to_hex(request->group_id, 32, gid_hex, sizeof(gid_hex));
     cJSON *e_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(e_tag, cJSON_CreateString("e"));
     cJSON_AddItemToArray(e_tag, cJSON_CreateString(gid_hex));
@@ -133,13 +133,13 @@ int frost_create_sign_request(const frost_group_t *group,
         cJSON *p_tag = cJSON_CreateArray();
         cJSON_AddItemToArray(p_tag, cJSON_CreateString("p"));
         char npub_hex[65];
-        bytes_to_hex(group->participants[i].npub, 32, npub_hex);
+        bytes_to_hex(group->participants[i].npub, 32, npub_hex, sizeof(npub_hex));
         cJSON_AddItemToArray(p_tag, cJSON_CreateString(npub_hex));
         cJSON_AddItemToArray(tags, p_tag);
     }
 
     char rid_hex[65];
-    bytes_to_hex(request->request_id, 32, rid_hex);
+    bytes_to_hex(request->request_id, 32, rid_hex, sizeof(rid_hex));
     cJSON *rid_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(rid_tag, cJSON_CreateString("request_id"));
     cJSON_AddItemToArray(rid_tag, cJSON_CreateString(rid_hex));
@@ -158,7 +158,7 @@ int frost_create_sign_request(const frost_group_t *group,
 
     if (request->has_policy) {
         char ph_hex[65];
-        bytes_to_hex(request->policy_hash, 32, ph_hex);
+        bytes_to_hex(request->policy_hash, 32, ph_hex, sizeof(ph_hex));
         cJSON *ph_tag = cJSON_CreateArray();
         cJSON_AddItemToArray(ph_tag, cJSON_CreateString("policy_hash"));
         cJSON_AddItemToArray(ph_tag, cJSON_CreateString(ph_hex));
@@ -169,9 +169,10 @@ int frost_create_sign_request(const frost_group_t *group,
     cJSON_AddStringToObject(content_obj, "message_type", msg_type_str);
     cJSON_AddStringToObject(content_obj, "request_id", rid_hex);
     if (request->payload && request->payload_len > 0) {
-        char *payload_hex = malloc(request->payload_len * 2 + 1);
+        size_t payload_hex_size = request->payload_len * 2 + 1;
+        char *payload_hex = malloc(payload_hex_size);
         if (payload_hex) {
-            bytes_to_hex(request->payload, request->payload_len, payload_hex);
+            bytes_to_hex(request->payload, request->payload_len, payload_hex, payload_hex_size);
             cJSON_AddStringToObject(content_obj, "payload", payload_hex);
             free(payload_hex);
         }
@@ -222,7 +223,7 @@ int frost_create_sign_response(const frost_group_t *group,
     cJSON *tags = cJSON_AddArrayToObject(root, "tags");
 
     char gid_hex[65];
-    bytes_to_hex(group->group_id, 32, gid_hex);
+    bytes_to_hex(group->group_id, 32, gid_hex, sizeof(gid_hex));
     cJSON *e_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(e_tag, cJSON_CreateString("e"));
     cJSON_AddItemToArray(e_tag, cJSON_CreateString(gid_hex));
@@ -231,7 +232,7 @@ int frost_create_sign_response(const frost_group_t *group,
     cJSON_AddItemToArray(tags, e_tag);
 
     char rid_hex[65];
-    bytes_to_hex(response->request_id, 32, rid_hex);
+    bytes_to_hex(response->request_id, 32, rid_hex, sizeof(rid_hex));
     cJSON *rid_tag = cJSON_CreateArray();
     cJSON_AddItemToArray(rid_tag, cJSON_CreateString("request_id"));
     cJSON_AddItemToArray(rid_tag, cJSON_CreateString(rid_hex));
@@ -263,10 +264,10 @@ int frost_create_sign_response(const frost_group_t *group,
 
     if (response->status == FROST_SIGN_STATUS_SIGNED) {
         char sig_hex[65];
-        bytes_to_hex(response->partial_signature, 32, sig_hex);
+        bytes_to_hex(response->partial_signature, 32, sig_hex, sizeof(sig_hex));
         cJSON_AddStringToObject(content_obj, "partial_signature", sig_hex);
         char nc_hex[67];
-        bytes_to_hex(response->nonce_commitment, 33, nc_hex);
+        bytes_to_hex(response->nonce_commitment, 33, nc_hex, sizeof(nc_hex));
         cJSON_AddStringToObject(content_obj, "nonce_commitment", nc_hex);
     } else if (response->status == FROST_SIGN_STATUS_REJECTED) {
         cJSON_AddStringToObject(content_obj, "status", "rejected");

--- a/main/policy.c
+++ b/main/policy.c
@@ -202,10 +202,10 @@ void policy_handle_get(const rpc_request_t *req, rpc_response_t *resp) {
     }
 
     char policy_hash_hex[65];
-    bytes_to_hex(bundle.policy_hash, POLICY_HASH_LEN, policy_hash_hex);
+    bytes_to_hex(bundle.policy_hash, POLICY_HASH_LEN, policy_hash_hex, sizeof(policy_hash_hex));
 
     char warden_pubkey_hex[65];
-    bytes_to_hex(bundle.warden_pubkey, POLICY_PUBKEY_LEN, warden_pubkey_hex);
+    bytes_to_hex(bundle.warden_pubkey, POLICY_PUBKEY_LEN, warden_pubkey_hex, sizeof(warden_pubkey_hex));
 
     char result[512];
     int written = snprintf(result, sizeof(result),

--- a/main/storage.c
+++ b/main/storage.c
@@ -190,10 +190,10 @@ int storage_load_share(const char *group, char *share_hex, size_t len) {
                 secure_memzero(&slot, sizeof(slot));
                 return STORAGE_ERR_DECRYPT;
             }
-            bytes_to_hex(decrypted, actual_len, share_hex);
+            bytes_to_hex(decrypted, actual_len, share_hex, len);
             secure_memzero(decrypted, sizeof(decrypted));
         } else {
-            bytes_to_hex(slot.share_data, actual_len, share_hex);
+            bytes_to_hex(slot.share_data, actual_len, share_hex, len);
         }
         secure_memzero(&slot, sizeof(slot));
         return STORAGE_OK;


### PR DESCRIPTION
Validates output buffer size to prevent overflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened buffer overflow protection for hex encoding operations throughout the application.

* **Refactor**
  * Updated hex encoding functions to include explicit buffer capacity validation. Calls now pass destination buffer size parameters to ensure safe encoding with proper error detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->