### PR TITLE
Add structured error context to protocol responses

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -2,6 +2,7 @@ idf_component_register(
     SRCS "main.c" "protocol.c" "serial.c" "storage.c" "storage_crypto.c" "frost_signer.c" "frost.c" "session.c"
          "nostr_frost.c" "nostr_frost_sign.c" "nostr_frost_dkg_events.c" "nostr_frost_nip46.c"
          "frost_crypto_ops.c" "frost_coordinator.c" "frost_dkg.c" "psbt.c" "policy.c"
+         "error_context.c"
     INCLUDE_DIRS "."
     REQUIRES esp_partition driver esp_driver_usb_serial_jtag esp_driver_uart esp_driver_gpio mbedtls crypto_asm libnostr-c noscrypt
     PRIV_REQUIRES secp256k1-frost espressif__cjson espressif__esp_websocket_client libwally-core

--- a/main/error_context.c
+++ b/main/error_context.c
@@ -1,0 +1,25 @@
+#include "error_context.h"
+#include <string.h>
+
+static const char *path_basename(const char *path) {
+    const char *last = path;
+    for (; *path; path++) {
+        if (*path == '/' || *path == '\\') {
+            last = path + 1;
+        }
+    }
+    return last;
+}
+
+void error_context_set(error_context_t *ctx, int code, const char *file,
+                       uint16_t line, const char *func) {
+    ctx->code = code;
+    ctx->line = line;
+
+    const char *base = path_basename(file);
+    strncpy(ctx->file, base, ERROR_FILE_LEN - 1);
+    ctx->file[ERROR_FILE_LEN - 1] = '\0';
+
+    strncpy(ctx->func, func, ERROR_FUNC_LEN - 1);
+    ctx->func[ERROR_FUNC_LEN - 1] = '\0';
+}

--- a/main/error_context.h
+++ b/main/error_context.h
@@ -1,0 +1,22 @@
+#ifndef ERROR_CONTEXT_H
+#define ERROR_CONTEXT_H
+
+#include <stdint.h>
+
+#define ERROR_FILE_LEN 32
+#define ERROR_FUNC_LEN 32
+
+typedef struct {
+    int code;
+    uint16_t line;
+    char file[ERROR_FILE_LEN];
+    char func[ERROR_FUNC_LEN];
+} error_context_t;
+
+void error_context_set(error_context_t *ctx, int code, const char *file,
+                       uint16_t line, const char *func);
+
+#define ERROR_SET(ctx, code) \
+    error_context_set((ctx), (code), __FILE__, __LINE__, __func__)
+
+#endif

--- a/main/frost_dkg.c
+++ b/main/frost_dkg.c
@@ -35,19 +35,19 @@ static dkg_session_t g_session;
 
 void dkg_init(const rpc_request_t *req, rpc_response_t *resp) {
     if (req->threshold < 2 || req->threshold > DKG_MAX_THRESHOLD) {
-        protocol_error(resp, req->id, -1, "Invalid threshold");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid threshold");
         return;
     }
     if (req->participant_count < req->threshold || req->participant_count > DKG_MAX_PARTICIPANTS) {
-        protocol_error(resp, req->id, -1, "Invalid participant count");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid participant count");
         return;
     }
     if (req->our_index < 1 || req->our_index > req->participant_count) {
-        protocol_error(resp, req->id, -1, "Invalid our_index");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid our_index");
         return;
     }
     if (strlen(req->group) == 0) {
-        protocol_error(resp, req->id, -1, "Group required");
+        PROTOCOL_ERROR(resp, req->id, -1, "Group required");
         return;
     }
 
@@ -66,7 +66,7 @@ void dkg_init(const rpc_request_t *req, rpc_response_t *resp) {
 
 void dkg_round1(const rpc_request_t *req, rpc_response_t *resp) {
     if (!g_session.active) {
-        protocol_error(resp, req->id, -1, "No active DKG session");
+        PROTOCOL_ERROR(resp, req->id, -1, "No active DKG session");
         return;
     }
 
@@ -80,7 +80,7 @@ void dkg_round1(const rpc_request_t *req, rpc_response_t *resp) {
                                          (uint8_t*)g_session.secret_shares,
                                          &g_session.secret_share_count);
     if (ret != 0) {
-        protocol_error(resp, req->id, -1, "Round 1 generation failed");
+        PROTOCOL_ERROR(resp, req->id, -1, "Round 1 generation failed");
         return;
     }
 
@@ -113,25 +113,25 @@ void dkg_round1(const rpc_request_t *req, rpc_response_t *resp) {
 
 void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
     if (!g_session.active) {
-        protocol_error(resp, req->id, -1, "No active DKG session");
+        PROTOCOL_ERROR(resp, req->id, -1, "No active DKG session");
         return;
     }
     if (g_session.peer_round1_count >= DKG_MAX_PARTICIPANTS) {
-        protocol_error(resp, req->id, -1, "Too many peer round1 entries");
+        PROTOCOL_ERROR(resp, req->id, -1, "Too many peer round1 entries");
         return;
     }
     if (req->peer_index < 1 || req->peer_index > g_session.participant_count) {
-        protocol_error(resp, req->id, -1, "Invalid peer_index");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid peer_index");
         return;
     }
     for (uint8_t i = 0; i < g_session.peer_round1_count; i++) {
         if (g_session.peer_round1[i].participant_index == req->peer_index) {
-            protocol_error(resp, req->id, -1, "Duplicate peer_index");
+            PROTOCOL_ERROR(resp, req->id, -1, "Duplicate peer_index");
             return;
         }
     }
     if (strlen(req->dkg_data) == 0) {
-        protocol_error(resp, req->id, -1, "dkg_data required");
+        PROTOCOL_ERROR(resp, req->id, -1, "dkg_data required");
         return;
     }
 
@@ -141,7 +141,7 @@ void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
 
     char *data = strdup(req->dkg_data);
     if (!data) {
-        protocol_error(resp, req->id, -1, "Memory error");
+        PROTOCOL_ERROR(resp, req->id, -1, "Memory error");
         return;
     }
 
@@ -152,20 +152,24 @@ void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
 
     if (!num_coeff_str || !coeffs_str || !zkp_r_str || !zkp_z_str) {
         free(data);
-        protocol_error(resp, req->id, -1, "Malformed dkg_data");
+        PROTOCOL_ERROR(resp, req->id, -1, "Malformed dkg_data");
         return;
     }
 
     peer->num_coefficients = (uint8_t)atoi(num_coeff_str + 18);
     if (peer->num_coefficients > MAX_THRESHOLD) {
         free(data);
-        protocol_error(resp, req->id, -1, "Too many coefficients");
+        PROTOCOL_ERROR(resp, req->id, -1, "Too many coefficients");
         return;
     }
 
     char *coeffs_start = coeffs_str + 26;
     char *coeffs_end = strchr(coeffs_start, '"');
-    if (!coeffs_end) { free(data); protocol_error(resp, req->id, -1, "Parse error"); return; }
+    if (!coeffs_end) {
+        free(data);
+        PROTOCOL_ERROR(resp, req->id, -1, "Parse error");
+        return;
+    }
     *coeffs_end = '\0';
 
     size_t coeffs_len = strlen(coeffs_start);
@@ -196,7 +200,7 @@ void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
 
     int ret = frost_dkg_round1_validate(peer);
     if (ret != 0) {
-        protocol_error(resp, req->id, -1, "Round 1 validation failed");
+        PROTOCOL_ERROR(resp, req->id, -1, "Round 1 validation failed");
         return;
     }
 
@@ -208,11 +212,11 @@ void dkg_round1_peer(const rpc_request_t *req, rpc_response_t *resp) {
 
 void dkg_round2(const rpc_request_t *req, rpc_response_t *resp) {
     if (!g_session.active) {
-        protocol_error(resp, req->id, -1, "No active DKG session");
+        PROTOCOL_ERROR(resp, req->id, -1, "No active DKG session");
         return;
     }
     if (g_session.secret_share_count == 0) {
-        protocol_error(resp, req->id, -1, "Round 1 not completed");
+        PROTOCOL_ERROR(resp, req->id, -1, "Round 1 not completed");
         return;
     }
 
@@ -241,25 +245,25 @@ void dkg_round2(const rpc_request_t *req, rpc_response_t *resp) {
 
 void dkg_receive_share(const rpc_request_t *req, rpc_response_t *resp) {
     if (!g_session.active) {
-        protocol_error(resp, req->id, -1, "No active DKG session");
+        PROTOCOL_ERROR(resp, req->id, -1, "No active DKG session");
         return;
     }
     if (g_session.received_share_count >= DKG_MAX_PARTICIPANTS) {
-        protocol_error(resp, req->id, -1, "Too many received shares");
+        PROTOCOL_ERROR(resp, req->id, -1, "Too many received shares");
         return;
     }
     if (req->peer_index < 1 || req->peer_index > g_session.participant_count) {
-        protocol_error(resp, req->id, -1, "Invalid peer_index");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid peer_index");
         return;
     }
     for (uint8_t i = 0; i < g_session.received_share_count; i++) {
         if (g_session.received_shares[i].generator_index == req->peer_index) {
-            protocol_error(resp, req->id, -1, "Duplicate share from peer");
+            PROTOCOL_ERROR(resp, req->id, -1, "Duplicate share from peer");
             return;
         }
     }
     if (strlen(req->share) != 64) {
-        protocol_error(resp, req->id, -1, "Invalid share length");
+        PROTOCOL_ERROR(resp, req->id, -1, "Invalid share length");
         return;
     }
 
@@ -276,7 +280,7 @@ void dkg_receive_share(const rpc_request_t *req, rpc_response_t *resp) {
 
 void dkg_finalize(const rpc_request_t *req, rpc_response_t *resp) {
     if (!g_session.active) {
-        protocol_error(resp, req->id, -1, "No active DKG session");
+        PROTOCOL_ERROR(resp, req->id, -1, "No active DKG session");
         return;
     }
 
@@ -316,7 +320,7 @@ void dkg_finalize(const rpc_request_t *req, rpc_response_t *resp) {
     if (ret != 0) {
         char err[64];
         snprintf(err, sizeof(err), "DKG finalize failed: %d", ret);
-        protocol_error(resp, req->id, -1, err);
+        PROTOCOL_ERROR(resp, req->id, -1, err);
         return;
     }
 
@@ -324,7 +328,7 @@ void dkg_finalize(const rpc_request_t *req, rpc_response_t *resp) {
     bytes_to_hex(final_share, 32, share_hex);
 
     if (storage_save_share(g_session.group, share_hex) != 0) {
-        protocol_error(resp, req->id, -1, "Failed to store share");
+        PROTOCOL_ERROR(resp, req->id, -1, "Failed to store share");
         return;
     }
 

--- a/main/frost_signer.c
+++ b/main/frost_signer.c
@@ -201,7 +201,7 @@ void frost_signer_cleanup(void) {
 void frost_get_pubkey(const char *group, rpc_response_t *resp) {
     frost_state_t state;
     if (load_frost_state(&state, group) != 0) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
         return;
     }
 
@@ -219,7 +219,7 @@ void frost_get_pubkey(const char *group, rpc_response_t *resp) {
 void frost_get_share_info(const char *group, rpc_response_t *resp) {
     frost_state_t state;
     if (load_frost_state(&state, group) != 0) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
         return;
     }
 
@@ -237,24 +237,24 @@ void frost_get_share_info(const char *group, rpc_response_t *resp) {
 
 void frost_commit(const char *group, const char *session_id_hex, const char *message_hex, rpc_response_t *resp) {
     if (strlen(session_id_hex) != SESSION_ID_HEX_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
         return;
     }
 
     uint8_t session_id[SESSION_ID_LEN];
     if (hex_to_bytes(session_id_hex, session_id, SESSION_ID_LEN) != SESSION_ID_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
         return;
     }
 
     if (strlen(message_hex) != SESSION_ID_HEX_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "message must be 32 bytes");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "message must be 32 bytes");
         return;
     }
 
     uint8_t message[SESSION_ID_LEN];
     if (hex_to_bytes(message_hex, message, SESSION_ID_LEN) != SESSION_ID_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid message hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid message hex");
         return;
     }
 
@@ -263,14 +263,14 @@ void frost_commit(const char *group, const char *session_id_hex, const char *mes
     int policy_ret = capture_policy_snapshot(&has_policy, policy_hash);
     if (policy_ret != 0) {
         secure_zero(policy_hash, sizeof(policy_hash));
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Policy bundle verification failed");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Policy bundle verification failed");
         return;
     }
 
     signing_session_t *s = alloc_session(session_id);
     if (!s) {
         secure_zero(policy_hash, sizeof(policy_hash));
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "No free session slots");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "No free session slots");
         return;
     }
 
@@ -280,7 +280,7 @@ void frost_commit(const char *group, const char *session_id_hex, const char *mes
 
     if (load_frost_state(&s->frost_state, group) != 0) {
         free_session(s);
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SHARE, "Share not found");
         return;
     }
 
@@ -302,7 +302,7 @@ void frost_commit(const char *group, const char *session_id_hex, const char *mes
     size_t commitment_len = 0;
     if (frost_create_commitment(&s->frost_state, &s->session, commitment, &commitment_len) != 0) {
         free_session(s);
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Failed to create commitment");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Failed to create commitment");
         return;
     }
 
@@ -320,30 +320,30 @@ void frost_commit(const char *group, const char *session_id_hex, const char *mes
 
 void frost_sign(const char *group, const char *session_id_hex, const char *commitments_hex, rpc_response_t *resp) {
     if (strlen(session_id_hex) != SESSION_ID_HEX_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
         return;
     }
 
     uint8_t session_id[SESSION_ID_LEN];
     if (hex_to_bytes(session_id_hex, session_id, SESSION_ID_LEN) != SESSION_ID_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
         return;
     }
 
     signing_session_t *s = find_session(session_id);
     if (!s) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
         return;
     }
 
     if (strcmp(s->group, group) != 0) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Group mismatch");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Group mismatch");
         return;
     }
 
     if (verify_policy_unchanged(s->has_policy, s->policy_hash) != 0) {
         free_session(s);
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Policy changed during session");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Policy changed during session");
         return;
     }
 
@@ -372,7 +372,7 @@ void frost_sign(const char *group, const char *session_id_hex, const char *commi
     }
     uint8_t total_participants = s->session.commitment_count + 1;
     if (total_participants < s->frost_state.threshold) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Not enough commitments for threshold");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Not enough commitments for threshold");
         return;
     }
     s->session.participant_count = total_participants;
@@ -383,7 +383,7 @@ void frost_sign(const char *group, const char *session_id_hex, const char *commi
     if (frost_sign_share(&s->frost_state, &s->session, s->session.message, s->session.message_len,
                          sig_share, &sig_share_len) != 0) {
         free_session(s);
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Signing failed");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Signing failed");
         return;
     }
 
@@ -423,43 +423,43 @@ void frost_signer_cleanup_stale(void) {
 
 void frost_add_share(const char *session_id_hex, const char *sig_share_hex, uint16_t share_index, rpc_response_t *resp) {
     if (strlen(session_id_hex) != SESSION_ID_HEX_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
         return;
     }
 
     uint8_t session_id[SESSION_ID_LEN];
     if (hex_to_bytes(session_id_hex, session_id, SESSION_ID_LEN) != SESSION_ID_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
         return;
     }
 
     signing_session_t *s = find_session(session_id);
     if (!s) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
         return;
     }
 
     if (s->session.state != SESSION_AWAITING_SHARES) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not awaiting shares");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not awaiting shares");
         return;
     }
 
     size_t hex_len = strlen(sig_share_hex);
     if (hex_len == 0 || hex_len > 72) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid signature share length");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid signature share length");
         return;
     }
 
     uint8_t share_bytes[36];
     int share_len = hex_to_bytes(sig_share_hex, share_bytes, sizeof(share_bytes));
     if (share_len < 0) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid signature share hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid signature share hex");
         return;
     }
 
     int idx = s->session.sig_share_count;
     if (idx >= MAX_PARTICIPANTS) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Too many signature shares");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Too many signature shares");
         return;
     }
 
@@ -475,31 +475,31 @@ void frost_add_share(const char *session_id_hex, const char *sig_share_hex, uint
 
 void frost_aggregate_shares(const char *session_id_hex, rpc_response_t *resp) {
     if (strlen(session_id_hex) != SESSION_ID_HEX_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "session_id must be 32 bytes");
         return;
     }
 
     uint8_t session_id[SESSION_ID_LEN];
     if (hex_to_bytes(session_id_hex, session_id, SESSION_ID_LEN) != SESSION_ID_LEN) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_PARAMS, "Invalid session_id hex");
         return;
     }
 
     signing_session_t *s = find_session(session_id);
     if (!s) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session not found");
         return;
     }
 
     if (s->session.sig_share_count < s->session.threshold) {
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Not enough shares");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Not enough shares");
         return;
     }
 
     uint8_t signature[SIGNATURE_LEN];
     if (frost_aggregate(&s->frost_state, &s->session, s->session.message, s->session.message_len, signature) != 0) {
         free_session(s);
-        protocol_error(resp, resp->id, PROTOCOL_ERR_SIGN, "Aggregation failed");
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Aggregation failed");
         return;
     }
 

--- a/main/main.c
+++ b/main/main.c
@@ -38,7 +38,7 @@ static void handle_list_shares(const rpc_request_t *req, rpc_response_t *resp) {
 
     int ret = snprintf(result, buf_size, "{\"shares\":[");
     if (ret < 0 || (size_t)ret >= buf_size) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer error");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer error");
         return;
     }
     offset = (size_t)ret;
@@ -47,7 +47,7 @@ static void handle_list_shares(const rpc_request_t *req, rpc_response_t *resp) {
         ret = snprintf(result + offset, buf_size - offset,
                        "%s\"%s\"", (i > 0) ? "," : "", groups[i]);
         if (ret < 0 || (size_t)ret >= buf_size - offset) {
-            protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer overflow");
+            PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer overflow");
             return;
         }
         offset += (size_t)ret;
@@ -55,7 +55,7 @@ static void handle_list_shares(const rpc_request_t *req, rpc_response_t *resp) {
 
     ret = snprintf(result + offset, buf_size - offset, "]}");
     if (ret < 0 || (size_t)ret >= buf_size - offset) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer overflow");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "Buffer overflow");
         return;
     }
 
@@ -70,19 +70,19 @@ static void handle_import_share(const rpc_request_t *req, rpc_response_t *resp) 
         protocol_success(resp, req->id, "{\"ok\":true}");
         break;
     case STORAGE_ERR_CRYPTO_NOT_INIT:
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage crypto not initialized");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage crypto not initialized");
         break;
     case STORAGE_ERR_INVALID_GROUP:
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid group name");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid group name");
         break;
     case STORAGE_ERR_INVALID_DATA:
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid share data");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid share data");
         break;
     case STORAGE_ERR_NO_SLOT:
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "No free storage slot");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "No free storage slot");
         break;
     default:
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
         break;
     }
 }
@@ -95,21 +95,21 @@ static void handle_delete_share(const rpc_request_t *req, rpc_response_t *resp) 
         protocol_success(resp, req->id, "{\"ok\":true}");
         break;
     case STORAGE_ERR_NOT_FOUND:
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Share not found");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Share not found");
         break;
     default:
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
         break;
     }
 }
 
 static void handle_bitcoin_parse(const rpc_request_t *req, rpc_response_t *resp) {
     if (!psbt_initialized) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "PSBT not initialized");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "PSBT not initialized");
         return;
     }
     if (!req->psbt) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing psbt");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing psbt");
         return;
     }
 
@@ -118,7 +118,7 @@ static void handle_bitcoin_parse(const rpc_request_t *req, rpc_response_t *resp)
     if (ret != 0) {
         char err_msg[64];
         snprintf(err_msg, sizeof(err_msg), "PSBT parse error: %d", ret);
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, err_msg);
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, err_msg);
         return;
     }
 
@@ -134,33 +134,33 @@ static void handle_bitcoin_parse(const rpc_request_t *req, rpc_response_t *resp)
 
 static void handle_bitcoin_sign(const rpc_request_t *req, rpc_response_t *resp) {
     if (!psbt_initialized) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "PSBT not initialized");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "PSBT not initialized");
         return;
     }
     if (!req->psbt) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing psbt");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing psbt");
         return;
     }
 
     psbt_summary_t summary;
     if (psbt_parse(req->psbt, &summary) != 0) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Failed to parse PSBT");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Failed to parse PSBT");
         return;
     }
 
     int policy_ret = policy_evaluate(summary.total_out_sats, summary.fee_sats);
     if (policy_ret == POLICY_ERR_DENIED) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_SIGN, "Policy denied");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_SIGN, "Policy denied");
         return;
     }
     if (policy_ret != 0) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_SIGN, "Policy evaluation failed");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_SIGN, "Policy evaluation failed");
         return;
     }
 
     uint8_t sighash[32];
     if (psbt_get_sighash(req->psbt, req->input_idx, sighash) != 0) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_SIGN, "Failed to get sighash");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_SIGN, "Failed to get sighash");
         return;
     }
 
@@ -235,7 +235,7 @@ static void handle_request(const rpc_request_t *req, rpc_response_t *resp) {
             policy_handle_get(req, resp);
             break;
         default:
-            protocol_error(resp, req->id, PROTOCOL_ERR_METHOD, "Method not found");
+            PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_METHOD, "Method not found");
     }
 }
 
@@ -290,7 +290,7 @@ void app_main(void) {
                 handle_request(&req, &resp);
                 protocol_free_request(&req);
             } else {
-                protocol_error(&resp, 0, PROTOCOL_ERR_PARSE, "Parse error");
+                PROTOCOL_ERROR(&resp, 0, PROTOCOL_ERR_PARSE, "Parse error");
             }
             if (resp.success) {
                 consecutive_errors = 0;

--- a/main/policy.c
+++ b/main/policy.c
@@ -151,12 +151,12 @@ int policy_check_hash(const policy_bundle_t *bundle, const uint8_t expected_hash
 void policy_handle_update(const rpc_request_t *req, rpc_response_t *resp) {
     size_t hex_len = strlen(req->policy_bundle);
     if (hex_len == 0) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing bundle parameter");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Missing bundle parameter");
         return;
     }
 
     if (hex_len != sizeof(policy_bundle_t) * 2) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid bundle length");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid bundle length");
         return;
     }
 
@@ -164,7 +164,7 @@ void policy_handle_update(const rpc_request_t *req, rpc_response_t *resp) {
     int byte_len = hex_to_bytes(req->policy_bundle, (uint8_t *)&bundle, sizeof(bundle));
     if (byte_len != (int)sizeof(policy_bundle_t)) {
         secure_memzero(&bundle, sizeof(bundle));
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid bundle hex");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid bundle hex");
         return;
     }
 
@@ -172,15 +172,15 @@ void policy_handle_update(const rpc_request_t *req, rpc_response_t *resp) {
     secure_memzero(&bundle, sizeof(bundle));
 
     if (ret == POLICY_ERR_INVALID_SIG) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid signature");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Invalid signature");
         return;
     }
     if (ret == POLICY_ERR_VERSION) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_PARAMS, "Unsupported version");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_PARAMS, "Unsupported version");
         return;
     }
     if (ret != 0) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Storage error");
         return;
     }
 
@@ -197,7 +197,7 @@ void policy_handle_get(const rpc_request_t *req, rpc_response_t *resp) {
     int ret = policy_load_bundle(&bundle);
     if (ret != 0) {
         secure_memzero(&bundle, sizeof(bundle));
-        protocol_error(resp, req->id, PROTOCOL_ERR_STORAGE, "Load error");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_STORAGE, "Load error");
         return;
     }
 
@@ -216,7 +216,7 @@ void policy_handle_get(const rpc_request_t *req, rpc_response_t *resp) {
     secure_memzero(&bundle, sizeof(bundle));
 
     if (written < 0 || (size_t)written >= sizeof(result)) {
-        protocol_error(resp, req->id, PROTOCOL_ERR_INTERNAL, "Response buffer overflow");
+        PROTOCOL_ERROR(resp, req->id, PROTOCOL_ERR_INTERNAL, "Response buffer overflow");
         return;
     }
 

--- a/main/protocol.c
+++ b/main/protocol.c
@@ -160,6 +160,14 @@ int protocol_format_response(const rpc_response_t *resp, char *buf, size_t len) 
         }
         cJSON_AddNumberToObject(error, "code", resp->error_code);
         cJSON_AddStringToObject(error, "message", resp->error_msg);
+        if (resp->error_ctx.file[0] != '\0') {
+            cJSON *ctx = cJSON_AddObjectToObject(error, "context");
+            if (ctx) {
+                cJSON_AddStringToObject(ctx, "file", resp->error_ctx.file);
+                cJSON_AddNumberToObject(ctx, "line", resp->error_ctx.line);
+                cJSON_AddStringToObject(ctx, "func", resp->error_ctx.func);
+            }
+        }
     }
 
     cJSON_bool ok = cJSON_PrintPreallocated(root, buf, (int)len, 0);
@@ -175,6 +183,7 @@ void protocol_success(rpc_response_t *resp, int id, const char *result) {
     resp->error_msg[0] = '\0';
     strncpy(resp->result, result, sizeof(resp->result) - 1);
     resp->result[sizeof(resp->result) - 1] = '\0';
+    memset(&resp->error_ctx, 0, sizeof(resp->error_ctx));
 }
 
 void protocol_error(rpc_response_t *resp, int id, int code, const char *message) {
@@ -184,4 +193,11 @@ void protocol_error(rpc_response_t *resp, int id, int code, const char *message)
     strncpy(resp->error_msg, message, sizeof(resp->error_msg) - 1);
     resp->error_msg[sizeof(resp->error_msg) - 1] = '\0';
     resp->result[0] = '\0';
+    memset(&resp->error_ctx, 0, sizeof(resp->error_ctx));
+}
+
+void protocol_error_ctx(rpc_response_t *resp, int id, int code, const char *message,
+                        const char *file, uint16_t line, const char *func) {
+    protocol_error(resp, id, code, message);
+    error_context_set(&resp->error_ctx, code, file, line, func);
 }

--- a/main/protocol.h
+++ b/main/protocol.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include "error_context.h"
 
 #define PROTOCOL_MAX_MESSAGE_LEN 16384
 #define PROTOCOL_MAX_GROUP_LEN 64
@@ -68,6 +69,7 @@ typedef struct {
     int error_code;
     char error_msg[128];
     char result[PROTOCOL_MAX_PSBT_LEN + 256];
+    error_context_t error_ctx;
 } rpc_response_t;
 
 int protocol_parse_request(const char *json, rpc_request_t *req);
@@ -75,5 +77,10 @@ void protocol_free_request(rpc_request_t *req);
 int protocol_format_response(const rpc_response_t *resp, char *buf, size_t len);
 void protocol_success(rpc_response_t *resp, int id, const char *result);
 void protocol_error(rpc_response_t *resp, int id, int code, const char *message);
+void protocol_error_ctx(rpc_response_t *resp, int id, int code, const char *message,
+                        const char *file, uint16_t line, const char *func);
+
+#define PROTOCOL_ERROR(resp, id, code, msg) \
+    protocol_error_ctx((resp), (id), (code), (msg), __FILE__, __LINE__, __func__)
 
 #endif

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -21,7 +21,7 @@ set_target_properties(test_frost PROPERTIES
 )
 
 if(EXISTS ${CJSON_DIR}/cJSON.c)
-    add_executable(test_protocol test_protocol.c ${CJSON_DIR}/cJSON.c ${MAIN_DIR}/protocol.c)
+    add_executable(test_protocol test_protocol.c ${CJSON_DIR}/cJSON.c ${MAIN_DIR}/protocol.c ${MAIN_DIR}/error_context.c)
     target_include_directories(test_protocol PRIVATE
         ${CJSON_DIR}
         ${MAIN_DIR}

--- a/test/native/test_protocol.c
+++ b/test/native/test_protocol.c
@@ -123,6 +123,27 @@ static int test_format_error(void) {
     if (strstr(buf, "\"error\"") == NULL) FAIL("missing error");
     if (strstr(buf, "\"code\":-1") == NULL) FAIL("missing code");
     if (strstr(buf, "Share not found") == NULL) FAIL("missing message");
+    if (strstr(buf, "\"context\"") != NULL) FAIL("should not have context");
+    PASS();
+    return 0;
+}
+
+static int test_format_error_with_context(void) {
+    TEST("format error response with context");
+    rpc_response_t resp;
+    PROTOCOL_ERROR(&resp, 3, -2, "Test error");
+    char buf[512];
+    int len = protocol_format_response(&resp, buf, sizeof(buf));
+    if (len <= 0) FAIL("format failed");
+    if (strstr(buf, "\"id\":3") == NULL) FAIL("missing id");
+    if (strstr(buf, "\"error\"") == NULL) FAIL("missing error");
+    if (strstr(buf, "\"code\":-2") == NULL) FAIL("missing code");
+    if (strstr(buf, "Test error") == NULL) FAIL("missing message");
+    if (strstr(buf, "\"context\"") == NULL) FAIL("missing context");
+    if (strstr(buf, "\"file\"") == NULL) FAIL("missing file");
+    if (strstr(buf, "\"line\"") == NULL) FAIL("missing line");
+    if (strstr(buf, "\"func\"") == NULL) FAIL("missing func");
+    if (strstr(buf, "test_protocol.c") == NULL) FAIL("wrong file");
     PASS();
     return 0;
 }
@@ -333,6 +354,7 @@ int main(void) {
     failures += test_parse_method_wrong_type();
     failures += test_format_success();
     failures += test_format_error();
+    failures += test_format_error_with_context();
     failures += test_all_methods();
     failures += test_threshold_boundary();
     failures += test_participant_count_boundary();


### PR DESCRIPTION
## Summary
- Add file/line/function context to error responses
- Replace protocol_error() calls with PROTOCOL_ERROR() macro
- Add test coverage for error context serialization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Error responses now include detailed context information (file location, line number, and function name) for improved debugging and error traceability.

* **Tests**
  * Added test coverage for error context functionality in responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->