### PR TITLE
Replace sprintf with snprintf in publish_event

### DIFF
--- a/main/frost_coordinator.c
+++ b/main/frost_coordinator.c
@@ -372,10 +372,11 @@ int frost_coordinator_unsubscribe(const char *subscription_id) {
 static int publish_event(const char *event_json) {
     if (!g_initialized) return -1;
 
-    char *msg = malloc(strlen(event_json) + 32);
+    size_t msg_len = strlen(event_json) + 12;
+    char *msg = malloc(msg_len);
     if (!msg) return -1;
 
-    sprintf(msg, "[\"EVENT\",%s]", event_json);
+    snprintf(msg, msg_len, "[\"EVENT\",%s]", event_json);
 
     int published = 0;
 #ifdef ESP_PLATFORM


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved memory efficiency and safety in event publishing by reducing allocated buffer usage and adopting length-limited string handling to prevent overruns.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->