### PR TITLE
Add session ID replay protection and fix TOCTOU in policy verification

### DIFF
--- a/main/frost_signer.c
+++ b/main/frost_signer.c
@@ -371,6 +371,29 @@ void frost_sign(const char *group, const char *session_id_hex,
     s->session.participant_count = total_participants;
     s->session.state = SESSION_AWAITING_SHARES;
 
+    uint16_t our_index = s->frost_state.share_index;
+
+    if (is_session_consumed(session_id)) {
+        for (uint8_t i = 0; i < s->session.sig_share_count && i < MAX_PARTICIPANTS; i++) {
+            if (s->session.sig_share_indices[i] == our_index) {
+                char cached_share_hex[73];
+                bytes_to_hex(s->session.sig_shares[i], s->session.sig_share_lens[i],
+                             cached_share_hex, sizeof(cached_share_hex));
+
+                char result[192];
+                snprintf(result, sizeof(result),
+                         "{\"signature_share\":\"%s\",\"index\":%d}",
+                         cached_share_hex, our_index);
+                protocol_success(resp, resp->id, result);
+                FROST_LOGI(TAG, "Returning cached signature share for session %.16s... (retry)",
+                           session_id_hex);
+                return;
+            }
+        }
+        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session already consumed");
+        return;
+    }
+
     bool policy_snapshot = s->has_policy;
     uint8_t policy_hash_snapshot[32];
     memcpy(policy_hash_snapshot, s->policy_hash, 32);
@@ -392,27 +415,6 @@ void frost_sign(const char *group, const char *session_id_hex,
         return;
     }
     secure_memzero(policy_hash_snapshot, sizeof(policy_hash_snapshot));
-
-    if (is_session_consumed(session_id)) {
-        for (uint8_t i = 0; i < s->session.sig_share_count && i < MAX_PARTICIPANTS; i++) {
-            if (s->session.sig_share_indices[i] == sign_result.index) {
-                char cached_share_hex[73];
-                bytes_to_hex(s->session.sig_shares[i], s->session.sig_share_lens[i],
-                             cached_share_hex, sizeof(cached_share_hex));
-
-                char result[192];
-                snprintf(result, sizeof(result),
-                         "{\"signature_share\":\"%s\",\"index\":%d}",
-                         cached_share_hex, sign_result.index);
-                protocol_success(resp, resp->id, result);
-                FROST_LOGI(TAG, "Returning cached signature share for session %.16s... (retry)",
-                           session_id_hex);
-                return;
-            }
-        }
-        PROTOCOL_ERROR(resp, resp->id, PROTOCOL_ERR_SIGN, "Session already consumed");
-        return;
-    }
 
     int share_idx = s->session.sig_share_count;
     if (share_idx >= MAX_PARTICIPANTS) {

--- a/test/hardware/test_hardware.py
+++ b/test/hardware/test_hardware.py
@@ -125,7 +125,7 @@ def test_frost_commit(ser):
         "params": {"group": test_group}
     })
 
-    print(f"  PASS")
+    print("  PASS")
     return True
 
 def test_frost_sign(ser):
@@ -156,10 +156,10 @@ def test_frost_sign(ser):
     # With empty commitments, we expect threshold error (need 2-of-3)
     if "error" in resp:
         assert "threshold" in resp["error"]["message"].lower(), f"unexpected error: {resp}"
-        print(f"  PASS (expected threshold error)")
+        print("  PASS (expected threshold error)")
     else:
         assert "signature_share" in resp["result"], "no signature_share in result"
-        print(f"  PASS")
+        print("  PASS")
 
     send_receive(ser, {
         "id": 33, "method": "delete_share",
@@ -204,7 +204,7 @@ def test_session_replay_protection(ser):
         "params": {"group": test_group}
     })
 
-    print(f"  PASS (replay blocked)")
+    print("  PASS (replay blocked)")
     return True
 
 def reset_device(ser):


### PR DESCRIPTION
- Add ring buffer to track consumed session IDs
- Reject replayed or already-active session IDs
- Verify policy unchanged after signing operation
- Zero sensitive data on all paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents session reuse and duplicate-session acceptance; enforces policy consistency before and after signing; returns cached signature shares when appropriate.
* **Security**
  * Zeroes sensitive policy data on error paths and strengthens handling to reduce information leakage.
* **Tests**
  * Adds a hardware replay-protection test, a reset helper, and stronger session ID generation for test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->