### PR TITLE
Add PIN attempt limiting for share storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build libwally-core
         run: |
-          sudo apt-get update && sudo apt-get install -y autoconf automake libtool
+          sudo apt-get update && sudo apt-get install -y autoconf automake libtool libmbedtls-dev
           cd libwally-core
           ./tools/autogen.sh
           ./configure --disable-elements --disable-tests
@@ -94,6 +94,7 @@ jobs:
           ./test_secure_element
           [ ! -f ./test_protocol ] || ./test_protocol
           [ ! -f ./test_psbt_fraud_integration ] || ./test_psbt_fraud_integration
+          [ ! -f ./test_pin_attempt_limit ] || ./test_pin_attempt_limit
 
   docs:
     runs-on: ubuntu-latest

--- a/Justfile
+++ b/Justfile
@@ -33,7 +33,7 @@ test:
     for t in test_frost test_session test_storage test_secure_element test_secresult \
              test_integration test_self_test test_hw_entropy test_anti_glitch test_psbt_fraud \
              test_frost_signer_core test_protocol test_integration_full test_psbt_fraud_integration \
-             test_coordinator test_coordinator_race; do
+             test_coordinator test_coordinator_race test_pin_attempt_limit; do
         [ ! -f "./$t" ] || ./$t
     done
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -29,6 +29,12 @@ ESP32-S3 FROST threshold signing device security documentation.
 
 - Shares encrypted with AES-256-GCM before flash storage
 - Key derived via HKDF-SHA256 from eFuse MAC + optional PIN
+- A software PIN attempt limiter (progressive lockout, device brick after repeated
+  failures) is present but **not production-ready as a brute-force defense**: without
+  a provisioned secure element or eFUSE-backed secret, its counter and keys live in
+  flash the attacker controls, so it is bypassable and the PIN remains offline
+  brute-forceable if flash is extracted. See #141 (hardware root of trust) and
+  #142 (corruption can contribute to bricking).
 - **PIN limitation:** PIN adds entropy but does not protect against offline brute-force
   if flash is extracted (no hardware-enforced rate limiting)
 - Each slot uses unique 12-byte random nonce
@@ -206,8 +212,12 @@ idf.py -DSDKCONFIG_DEFAULTS="sdkconfig.defaults;sdkconfig.defaults.secureboot" b
 ## Known Limitations
 
 - MAC address readable, used in key derivation
-- PIN not rate-limited at hardware level; a weak or short PIN provides no meaningful
-  protection against offline brute-force when flash can be extracted
+- PIN attempt limiting is software-only and not hardware-enforced; its counter can be
+  reset by erasing flash and the PIN is still offline brute-forceable when flash is
+  extracted. It is not production-ready as a brute-force defense until backed by a
+  hardware root of trust.
+- The PIN brick treats any decrypt failure (including flash corruption) as a failed
+  attempt, so storage corruption can contribute to bricking a device
 - Single-threaded, no concurrent request handling
 - Secure boot requires careful key management (key loss = bricked device)
 

--- a/components/crypto_asm/include/crypto_asm.h
+++ b/components/crypto_asm/include/crypto_asm.h
@@ -28,6 +28,10 @@ uint32_t ct_select32(uint32_t a, uint32_t b, uint32_t condition);
 void ct_select_bytes(void *out, const void *a, const void *b, size_t len, uint32_t condition);
 void ct_cswap32(uint32_t *a, uint32_t *b, uint32_t condition);
 
+static inline int secure_memcmp(const void *a, const void *b, size_t len) {
+    return ct_compare(a, b, len);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/main/main.c
+++ b/main/main.c
@@ -77,6 +77,11 @@ static void handle_unlock(const rpc_request_t *req, rpc_response_t *resp) {
     }
 
     int ret = storage_crypto_init(req->pin);
+    if (ret == ERR_PIN_BRICKED) {
+        PROTOCOL_ERROR(resp, req->id, ERR_PIN_BRICKED,
+                       "Device bricked after too many PIN attempts");
+        return;
+    }
     if (ret == ERR_PIN_LOCKED) {
         PROTOCOL_ERROR(resp, req->id, ERR_PIN_LOCKED, "Device locked");
         return;

--- a/main/storage.c
+++ b/main/storage.c
@@ -553,6 +553,9 @@ int storage_load_share(const char *group, char *share_hex, size_t len) {
             secure_memzero(&slot, sizeof(slot));
             return STORAGE_ERR_DECRYPT;
         }
+        // A correct GCM tag proves the PIN was right; clear the failure counter
+        // so an occasional mistype never accumulates toward the brick threshold.
+        storage_crypto_record_attempt(true);
         bytes_to_hex(decrypted, actual_len, share_hex, len);
         secure_memzero(decrypted, sizeof(decrypted));
         secure_memzero(&slot, sizeof(slot));

--- a/main/storage_crypto.c
+++ b/main/storage_crypto.c
@@ -20,15 +20,15 @@
 #include "esp_timer.h"
 #include "nvs_flash.h"
 #include "nvs.h"
-static uint32_t get_time_ms(void) {
-    return (uint32_t)(esp_timer_get_time() / 1000);
+static uint64_t get_time_ms(void) {
+    return (uint64_t)(esp_timer_get_time() / 1000);
 }
 #else
 #include <time.h>
-static uint32_t get_time_ms(void) {
+static uint64_t get_time_ms(void) {
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts);
-    return (uint32_t)(ts.tv_sec * 1000 + ts.tv_nsec / 1000000);
+    return (uint64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 #endif
 
@@ -39,12 +39,12 @@ static uint32_t get_time_ms(void) {
 #define PIN_PBKDF2_ITERATIONS 100000
 #define PIN_PBKDF2_SALT_LEN   16
 
-#define NVS_NAMESPACE     "pin_rl"
-#define NVS_KEY_FAILURES  "failures"
-#define NVS_KEY_LOCKOUT   "lockout"
-#define NVS_KEY_BRICKED   "bricked"
-#define NVS_KEY_SALT      "salt"
-#define NVS_KEY_HMAC      "hmac"
+#define NVS_NAMESPACE    "pin_rl"
+#define NVS_KEY_FAILURES "failures"
+#define NVS_KEY_LOCKOUT  "lockout"
+#define NVS_KEY_BRICKED  "bricked"
+#define NVS_KEY_SALT     "salt"
+#define NVS_KEY_HMAC     "hmac"
 
 #define SE_SLOT_PIN_STATE 0
 #define SE_SLOT_HMAC_KEY  1
@@ -53,7 +53,7 @@ static uint32_t get_time_ms(void) {
 typedef struct __attribute__((packed)) {
     uint8_t magic[4];
     uint8_t failed_attempts;
-    uint32_t lockout_deadline;
+    uint64_t lockout_deadline;
     uint8_t bricked;
     uint8_t reserved[2];
 } pin_state_t;
@@ -142,11 +142,11 @@ static int get_hmac_secret_key(uint8_t key_out[HMAC_KEY_SIZE]) {
 #endif
 }
 
-static void compute_state_hmac(const pin_state_t *state, uint8_t hmac_out[32]) {
+static int compute_state_hmac(const pin_state_t *state, uint8_t hmac_out[32]) {
     uint8_t secret_key[HMAC_KEY_SIZE];
     if (get_hmac_secret_key(secret_key) != 0) {
-        memset(hmac_out, 0, 32);
-        return;
+        secure_memzero(secret_key, sizeof(secret_key));
+        return -1;
     }
 
     uint8_t ipad[64], opad[64];
@@ -181,6 +181,7 @@ static void compute_state_hmac(const pin_state_t *state, uint8_t hmac_out[32]) {
     secure_memzero(opad, sizeof(opad));
     secure_memzero(key_padded, sizeof(key_padded));
     secure_memzero(inner_hash, sizeof(inner_hash));
+    return 0;
 }
 
 static void load_pin_state(void) {
@@ -207,13 +208,13 @@ static void load_pin_state(void) {
         nvs_handle_t handle;
         if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) == ESP_OK) {
             uint8_t failures = 0;
-            uint32_t lockout = 0;
+            uint64_t lockout = 0;
             uint8_t bricked = 0;
             uint8_t stored_hmac[32];
             size_t hmac_len = sizeof(stored_hmac);
 
             nvs_get_u8(handle, NVS_KEY_FAILURES, &failures);
-            nvs_get_u32(handle, NVS_KEY_LOCKOUT, &lockout);
+            nvs_get_u64(handle, NVS_KEY_LOCKOUT, &lockout);
             nvs_get_u8(handle, NVS_KEY_BRICKED, &bricked);
 
             pin_state_t temp_state;
@@ -226,8 +227,8 @@ static void load_pin_state(void) {
             if (nvs_get_blob(handle, NVS_KEY_HMAC, stored_hmac, &hmac_len) == ESP_OK &&
                 hmac_len == 32) {
                 uint8_t computed_hmac[32];
-                compute_state_hmac(&temp_state, computed_hmac);
-                if (secure_memcmp(stored_hmac, computed_hmac, 32) == 0) {
+                if (compute_state_hmac(&temp_state, computed_hmac) == 0 &&
+                    secure_memcmp(stored_hmac, computed_hmac, 32) == 0) {
                     memcpy(&pin_state, &temp_state, sizeof(pin_state));
                 }
             }
@@ -250,10 +251,13 @@ static void save_pin_state(void) {
         nvs_handle_t handle;
         if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) == ESP_OK) {
             uint8_t hmac[32];
-            compute_state_hmac(&pin_state, hmac);
+            if (compute_state_hmac(&pin_state, hmac) != 0) {
+                nvs_close(handle);
+                return;
+            }
 
             nvs_set_u8(handle, NVS_KEY_FAILURES, pin_state.failed_attempts);
-            nvs_set_u32(handle, NVS_KEY_LOCKOUT, pin_state.lockout_deadline);
+            nvs_set_u64(handle, NVS_KEY_LOCKOUT, pin_state.lockout_deadline);
             nvs_set_u8(handle, NVS_KEY_BRICKED, pin_state.bricked);
             nvs_set_blob(handle, NVS_KEY_HMAC, hmac, sizeof(hmac));
             nvs_commit(handle);
@@ -419,7 +423,7 @@ int storage_crypto_check_rate_limit(void) {
     }
 
     if (pin_state.lockout_deadline > 0) {
-        uint32_t now = get_time_ms();
+        uint64_t now = get_time_ms();
         if (now < pin_state.lockout_deadline) {
             return ERR_PIN_MUST_WAIT;
         }
@@ -479,11 +483,11 @@ uint32_t storage_crypto_get_delay_remaining(void) {
         return 0;
     }
 
-    uint32_t now = get_time_ms();
+    uint64_t now = get_time_ms();
     if (now >= pin_state.lockout_deadline) {
         return 0;
     }
-    return pin_state.lockout_deadline - now;
+    return (uint32_t)(pin_state.lockout_deadline - now);
 }
 
 bool storage_crypto_is_bricked(void) {

--- a/main/storage_crypto.c
+++ b/main/storage_crypto.c
@@ -5,9 +5,11 @@
 #include "error_codes.h"
 #include "random_utils.h"
 #include "crypto_asm.h"
+#include "secure_element.h"
 #include <mbedtls/gcm.h>
 #include <mbedtls/hkdf.h>
-#include <mbedtls/md.h>
+#include <mbedtls/pkcs5.h>
+#include <mbedtls/sha256.h>
 #include <stdbool.h>
 #include <string.h>
 
@@ -33,48 +35,162 @@ static uint32_t get_time_ms(void) {
 #define TAG            "storage_crypto"
 #define DEVICE_ID_SIZE 6
 
-#define PIN_RATE_LIMIT_WINDOW_MS   60000
-#define PIN_RATE_LIMIT_MAX         3
-#define PIN_LOCKOUT_MS             300000
-#define PIN_LOCKOUT_FAILURE_THRESH 5
+#define PIN_MAX_ATTEMPTS      21
+#define PIN_PBKDF2_ITERATIONS 100000
+#define PIN_PBKDF2_SALT_LEN   16
 
-#define NVS_NAMESPACE    "pin_rl"
-#define NVS_KEY_FAILURES "failures"
-#define NVS_KEY_LOCKOUT  "lockout"
+#define NVS_NAMESPACE     "pin_rl"
+#define NVS_KEY_FAILURES  "failures"
+#define NVS_KEY_LAST_FAIL "last_fail"
+#define NVS_KEY_BRICKED   "bricked"
+#define NVS_KEY_SALT      "salt"
+#define NVS_KEY_HMAC      "hmac"
+
+#define SE_SLOT_PIN_STATE 0
+
+typedef struct __attribute__((packed)) {
+    uint8_t magic[4];
+    uint8_t failed_attempts;
+    uint32_t last_failure_time;
+    uint8_t bricked;
+    uint8_t reserved[2];
+} pin_state_t;
+
+#define PIN_STATE_MAGIC "PIN\0"
+#define PIN_STATE_SIZE  sizeof(pin_state_t)
 
 static uint8_t storage_key[STORAGE_CRYPTO_KEY_SIZE];
 static bool key_initialized = false;
+static uint8_t pin_salt[PIN_PBKDF2_SALT_LEN];
+static bool salt_initialized = false;
 
-static uint32_t pin_attempt_times[PIN_RATE_LIMIT_MAX];
-static uint8_t pin_attempt_count = 0;
-static uint32_t pin_lockout_until = 0;
-static uint8_t pin_consecutive_failures = 0;
+static pin_state_t pin_state;
+static bool pin_state_loaded = false;
+static bool se_available = false;
 
-static void load_rate_limit_state(void) {
-#ifdef ESP_PLATFORM
-    nvs_handle_t handle;
-    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) == ESP_OK) {
-        uint8_t failures = 0;
-        uint32_t lockout = 0;
-        nvs_get_u8(handle, NVS_KEY_FAILURES, &failures);
-        nvs_get_u32(handle, NVS_KEY_LOCKOUT, &lockout);
-        nvs_close(handle);
-        pin_consecutive_failures = failures;
-        pin_lockout_until = lockout;
+static void compute_state_hmac(const pin_state_t *state, const uint8_t *device_id,
+                               uint8_t hmac_out[32]) {
+    uint8_t ipad[64], opad[64];
+    uint8_t key_padded[64];
+    memset(key_padded, 0, sizeof(key_padded));
+    memcpy(key_padded, device_id, DEVICE_ID_SIZE);
+
+    for (int i = 0; i < 64; i++) {
+        ipad[i] = key_padded[i] ^ 0x36;
+        opad[i] = key_padded[i] ^ 0x5c;
     }
-#endif
+
+    mbedtls_sha256_context ctx;
+    uint8_t inner_hash[32];
+
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, ipad, 64);
+    mbedtls_sha256_update(&ctx, (const uint8_t *)state, PIN_STATE_SIZE);
+    mbedtls_sha256_finish(&ctx, inner_hash);
+    mbedtls_sha256_free(&ctx);
+
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, opad, 64);
+    mbedtls_sha256_update(&ctx, inner_hash, 32);
+    mbedtls_sha256_finish(&ctx, hmac_out);
+    mbedtls_sha256_free(&ctx);
+
+    secure_memzero(ipad, sizeof(ipad));
+    secure_memzero(opad, sizeof(opad));
+    secure_memzero(key_padded, sizeof(key_padded));
+    secure_memzero(inner_hash, sizeof(inner_hash));
 }
 
-static void save_rate_limit_state(void) {
-#ifdef ESP_PLATFORM
-    nvs_handle_t handle;
-    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) == ESP_OK) {
-        nvs_set_u8(handle, NVS_KEY_FAILURES, pin_consecutive_failures);
-        nvs_set_u32(handle, NVS_KEY_LOCKOUT, pin_lockout_until);
-        nvs_commit(handle);
-        nvs_close(handle);
+static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]);
+
+static void load_pin_state(void) {
+    if (pin_state_loaded) {
+        return;
     }
+
+    memcpy(pin_state.magic, PIN_STATE_MAGIC, 4);
+    pin_state.failed_attempts = 0;
+    pin_state.last_failure_time = 0;
+    pin_state.bricked = 0;
+    memset(pin_state.reserved, 0, sizeof(pin_state.reserved));
+
+    if (se_init() == SE_OK && se_is_provisioned()) {
+        se_available = true;
+        uint8_t se_data[SE_SLOT_SIZE];
+        if (se_read_slot(SE_SLOT_PIN_STATE, se_data, sizeof(se_data)) == SE_OK) {
+            if (memcmp(se_data, PIN_STATE_MAGIC, 4) == 0) {
+                memcpy(&pin_state, se_data, PIN_STATE_SIZE);
+            }
+        }
+    } else {
+#ifdef ESP_PLATFORM
+        nvs_handle_t handle;
+        if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) == ESP_OK) {
+            uint8_t device_id[DEVICE_ID_SIZE];
+            if (get_device_id(device_id) == 0) {
+                uint8_t failures = 0;
+                uint32_t last_fail = 0;
+                uint8_t bricked = 0;
+                uint8_t stored_hmac[32];
+                size_t hmac_len = sizeof(stored_hmac);
+
+                nvs_get_u8(handle, NVS_KEY_FAILURES, &failures);
+                nvs_get_u32(handle, NVS_KEY_LAST_FAIL, &last_fail);
+                nvs_get_u8(handle, NVS_KEY_BRICKED, &bricked);
+
+                pin_state_t temp_state;
+                memcpy(temp_state.magic, PIN_STATE_MAGIC, 4);
+                temp_state.failed_attempts = failures;
+                temp_state.last_failure_time = last_fail;
+                temp_state.bricked = bricked;
+                memset(temp_state.reserved, 0, sizeof(temp_state.reserved));
+
+                if (nvs_get_blob(handle, NVS_KEY_HMAC, stored_hmac, &hmac_len) == ESP_OK &&
+                    hmac_len == 32) {
+                    uint8_t computed_hmac[32];
+                    compute_state_hmac(&temp_state, device_id, computed_hmac);
+                    if (secure_memcmp(stored_hmac, computed_hmac, 32) == 0) {
+                        memcpy(&pin_state, &temp_state, sizeof(pin_state));
+                    }
+                }
+                secure_memzero(device_id, sizeof(device_id));
+            }
+            nvs_close(handle);
+        }
 #endif
+    }
+
+    pin_state_loaded = true;
+}
+
+static void save_pin_state(void) {
+    if (se_available) {
+        uint8_t se_data[SE_SLOT_SIZE];
+        memset(se_data, 0, sizeof(se_data));
+        memcpy(se_data, &pin_state, PIN_STATE_SIZE);
+        se_write_slot(SE_SLOT_PIN_STATE, se_data, sizeof(se_data));
+    } else {
+#ifdef ESP_PLATFORM
+        nvs_handle_t handle;
+        if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) == ESP_OK) {
+            uint8_t device_id[DEVICE_ID_SIZE];
+            if (get_device_id(device_id) == 0) {
+                uint8_t hmac[32];
+                compute_state_hmac(&pin_state, device_id, hmac);
+
+                nvs_set_u8(handle, NVS_KEY_FAILURES, pin_state.failed_attempts);
+                nvs_set_u32(handle, NVS_KEY_LAST_FAIL, pin_state.last_failure_time);
+                nvs_set_u8(handle, NVS_KEY_BRICKED, pin_state.bricked);
+                nvs_set_blob(handle, NVS_KEY_HMAC, hmac, sizeof(hmac));
+                nvs_commit(handle);
+                secure_memzero(device_id, sizeof(device_id));
+            }
+            nvs_close(handle);
+        }
+#endif
+    }
 }
 
 static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]) {
@@ -108,94 +224,215 @@ static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]) {
 #endif
 }
 
-// The "v1" in the salt is the HKDF key derivation version, not the storage format version.
-// Do not change this value - it would invalidate all existing encrypted data.
-static const uint8_t HKDF_SALT[] = "keep-esp32-share-storage-v1";
+static int init_or_load_salt(void) {
+    if (salt_initialized) {
+        return 0;
+    }
+
+#ifdef ESP_PLATFORM
+    nvs_handle_t handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) == ESP_OK) {
+        size_t salt_len = PIN_PBKDF2_SALT_LEN;
+        if (nvs_get_blob(handle, NVS_KEY_SALT, pin_salt, &salt_len) == ESP_OK &&
+            salt_len == PIN_PBKDF2_SALT_LEN) {
+            salt_initialized = true;
+            nvs_close(handle);
+            return 0;
+        }
+        if (rng_fill_checked(pin_salt, PIN_PBKDF2_SALT_LEN) != 0) {
+            nvs_close(handle);
+            return -1;
+        }
+        nvs_set_blob(handle, NVS_KEY_SALT, pin_salt, PIN_PBKDF2_SALT_LEN);
+        nvs_commit(handle);
+        nvs_close(handle);
+        salt_initialized = true;
+        return 0;
+    }
+    return -1;
+#else
+    if (rng_fill_checked(pin_salt, PIN_PBKDF2_SALT_LEN) != 0) {
+        return -1;
+    }
+    salt_initialized = true;
+    return 0;
+#endif
+}
+
 static const uint8_t HKDF_INFO[] = "share-encryption-key";
 
 static int derive_key(const uint8_t *device_id, size_t device_id_len, const uint8_t *pin,
                       size_t pin_len, uint8_t *key_out) {
-    if (device_id_len > DEVICE_ID_SIZE) {
+    if (device_id_len > DEVICE_ID_SIZE || !pin || pin_len == 0) {
         return -1;
     }
 
-    uint8_t ikm[DEVICE_ID_SIZE + STORAGE_CRYPTO_MAX_PIN_LEN];
-    size_t ikm_len = device_id_len;
-    memcpy(ikm, device_id, device_id_len);
-
-    if (pin && pin_len > 0) {
-        size_t copy_len =
-            pin_len < STORAGE_CRYPTO_MAX_PIN_LEN ? pin_len : STORAGE_CRYPTO_MAX_PIN_LEN;
-        memcpy(ikm + device_id_len, pin, copy_len);
-        ikm_len += copy_len;
+    if (init_or_load_salt() != 0) {
+        return -1;
     }
 
-    int ret = mbedtls_hkdf(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), HKDF_SALT,
-                           sizeof(HKDF_SALT) - 1, ikm, ikm_len, HKDF_INFO, sizeof(HKDF_INFO) - 1,
-                           key_out, STORAGE_CRYPTO_KEY_SIZE);
+    uint8_t pbkdf2_salt[PIN_PBKDF2_SALT_LEN + DEVICE_ID_SIZE];
+    memcpy(pbkdf2_salt, pin_salt, PIN_PBKDF2_SALT_LEN);
+    memcpy(pbkdf2_salt + PIN_PBKDF2_SALT_LEN, device_id, device_id_len);
 
-    secure_memzero(ikm, sizeof(ikm));
+    uint8_t stretched[32];
+    int ret = mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA256, pin, pin_len, pbkdf2_salt,
+                                            sizeof(pbkdf2_salt), PIN_PBKDF2_ITERATIONS,
+                                            sizeof(stretched), stretched);
+    secure_memzero(pbkdf2_salt, sizeof(pbkdf2_salt));
+
+    if (ret != 0) {
+        secure_memzero(stretched, sizeof(stretched));
+        return -1;
+    }
+
+    ret = mbedtls_hkdf(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), NULL, 0, stretched,
+                       sizeof(stretched), HKDF_INFO, sizeof(HKDF_INFO) - 1, key_out,
+                       STORAGE_CRYPTO_KEY_SIZE);
+    secure_memzero(stretched, sizeof(stretched));
+
     return (ret == 0) ? 0 : -1;
 }
 
-static bool rate_limit_loaded = false;
+static uint32_t get_delay_ms(uint8_t attempts) {
+    if (attempts <= 3) {
+        return 0;
+    }
+    if (attempts <= 6) {
+        return 15 * 1000;
+    }
+    if (attempts <= 9) {
+        return 60 * 1000;
+    }
+    if (attempts <= 12) {
+        return 15 * 60 * 1000;
+    }
+    return UINT32_MAX;
+}
+
+static void wipe_secrets(void) {
+    secure_memzero(storage_key, sizeof(storage_key));
+    key_initialized = false;
+
+#ifdef ESP_PLATFORM
+    nvs_handle_t handle;
+    if (nvs_open("storage", NVS_READWRITE, &handle) == ESP_OK) {
+        nvs_erase_all(handle);
+        nvs_commit(handle);
+        nvs_close(handle);
+    }
+#endif
+
+    if (se_available) {
+        uint8_t zeros[SE_SLOT_SIZE];
+        memset(zeros, 0, sizeof(zeros));
+        for (int i = 1; i < SE_SLOT_COUNT; i++) {
+            se_write_slot(i, zeros, sizeof(zeros));
+        }
+    }
+}
 
 int storage_crypto_check_rate_limit(void) {
-    if (!rate_limit_loaded) {
-        load_rate_limit_state();
-        rate_limit_loaded = true;
+    load_pin_state();
+
+    if (pin_state.bricked) {
+        return ERR_PIN_BRICKED;
     }
 
-    uint32_t now = get_time_ms();
+    if (pin_state.failed_attempts >= PIN_MAX_ATTEMPTS) {
+        return ERR_PIN_BRICKED;
+    }
 
-    if (pin_lockout_until > 0) {
-        if ((int32_t)(now - pin_lockout_until) < 0) {
-            return ERR_PIN_LOCKED;
+    uint32_t delay_ms = get_delay_ms(pin_state.failed_attempts);
+    if (delay_ms == UINT32_MAX) {
+        return ERR_PIN_BRICKED;
+    }
+
+    if (delay_ms > 0 && pin_state.last_failure_time > 0) {
+        uint32_t now = get_time_ms();
+        uint32_t elapsed = now - pin_state.last_failure_time;
+        if (elapsed < delay_ms) {
+            return ERR_PIN_MUST_WAIT;
         }
-        pin_lockout_until = 0;
-        pin_consecutive_failures = 0;
-        save_rate_limit_state();
-    }
-
-    int recent = 0;
-    for (int i = 0; i < pin_attempt_count; i++) {
-        if ((now - pin_attempt_times[i]) < PIN_RATE_LIMIT_WINDOW_MS) {
-            recent++;
-        }
-    }
-    if (recent >= PIN_RATE_LIMIT_MAX) {
-        return ERR_PIN_MUST_WAIT;
     }
 
     return 0;
 }
 
 void storage_crypto_record_attempt(bool success) {
-    uint32_t now = get_time_ms();
-
-    if (pin_attempt_count < PIN_RATE_LIMIT_MAX) {
-        pin_attempt_times[pin_attempt_count++] = now;
-    } else {
-        memmove(pin_attempt_times, pin_attempt_times + 1,
-                (PIN_RATE_LIMIT_MAX - 1) * sizeof(pin_attempt_times[0]));
-        pin_attempt_times[PIN_RATE_LIMIT_MAX - 1] = now;
-    }
+    load_pin_state();
 
     if (success) {
-        pin_consecutive_failures = 0;
+        pin_state.failed_attempts = 0;
+        pin_state.last_failure_time = 0;
     } else {
-        if (pin_consecutive_failures < UINT8_MAX) {
-            pin_consecutive_failures++;
+        if (pin_state.failed_attempts < UINT8_MAX) {
+            pin_state.failed_attempts++;
         }
-        if (pin_consecutive_failures >= PIN_LOCKOUT_FAILURE_THRESH) {
-            pin_lockout_until = now + PIN_LOCKOUT_MS;
-            ESP_LOGW(TAG, "PIN lockout activated for %d seconds", PIN_LOCKOUT_MS / 1000);
+        pin_state.last_failure_time = get_time_ms();
+
+        if (pin_state.failed_attempts >= PIN_MAX_ATTEMPTS) {
+            ESP_LOGE(TAG, "Max PIN attempts exceeded - wiping device");
+            pin_state.bricked = 1;
+            save_pin_state();
+            wipe_secrets();
+            return;
+        }
+
+        uint32_t delay_ms = get_delay_ms(pin_state.failed_attempts);
+        if (delay_ms > 0 && delay_ms != UINT32_MAX) {
+            ESP_LOGW(TAG, "PIN attempt %d/%d - next attempt in %lu seconds",
+                     pin_state.failed_attempts, PIN_MAX_ATTEMPTS, (unsigned long)(delay_ms / 1000));
         }
     }
-    save_rate_limit_state();
+    save_pin_state();
+}
+
+uint8_t storage_crypto_get_attempts(void) {
+    load_pin_state();
+    return pin_state.failed_attempts;
+}
+
+uint8_t storage_crypto_get_max_attempts(void) {
+    return PIN_MAX_ATTEMPTS;
+}
+
+uint32_t storage_crypto_get_delay_remaining(void) {
+    load_pin_state();
+
+    if (pin_state.bricked || pin_state.failed_attempts >= PIN_MAX_ATTEMPTS) {
+        return UINT32_MAX;
+    }
+
+    uint32_t delay_ms = get_delay_ms(pin_state.failed_attempts);
+    if (delay_ms == 0 || delay_ms == UINT32_MAX) {
+        return delay_ms;
+    }
+
+    if (pin_state.last_failure_time == 0) {
+        return 0;
+    }
+
+    uint32_t now = get_time_ms();
+    uint32_t elapsed = now - pin_state.last_failure_time;
+    if (elapsed >= delay_ms) {
+        return 0;
+    }
+    return delay_ms - elapsed;
+}
+
+bool storage_crypto_is_bricked(void) {
+    load_pin_state();
+    return pin_state.bricked != 0 || pin_state.failed_attempts >= PIN_MAX_ATTEMPTS;
 }
 
 int storage_crypto_init(const char *pin) {
+    load_pin_state();
+
+    if (pin_state.bricked || pin_state.failed_attempts >= PIN_MAX_ATTEMPTS) {
+        return ERR_PIN_BRICKED;
+    }
+
     int rate_limit = storage_crypto_check_rate_limit();
     if (rate_limit != 0) {
         return rate_limit;
@@ -217,9 +454,6 @@ int storage_crypto_init(const char *pin) {
 
     if (ret == 0) {
         key_initialized = true;
-        storage_crypto_record_attempt(true);
-    } else {
-        storage_crypto_record_attempt(false);
     }
     return ret;
 }
@@ -301,10 +535,24 @@ int storage_crypto_decrypt(const uint8_t *ciphertext, size_t ciphertext_len, con
 
 #ifdef UNIT_TEST
 void storage_crypto_reset_rate_limit(void) {
-    pin_attempt_count = 0;
-    pin_lockout_until = 0;
-    pin_consecutive_failures = 0;
-    memset(pin_attempt_times, 0, sizeof(pin_attempt_times));
-    rate_limit_loaded = false;
+    memcpy(pin_state.magic, PIN_STATE_MAGIC, 4);
+    pin_state.failed_attempts = 0;
+    pin_state.last_failure_time = 0;
+    pin_state.bricked = 0;
+    memset(pin_state.reserved, 0, sizeof(pin_state.reserved));
+    pin_state_loaded = true;
+    salt_initialized = false;
+    se_available = false;
+}
+
+void storage_crypto_set_attempts_for_test(uint8_t attempts) {
+    load_pin_state();
+    pin_state.failed_attempts = attempts;
+    pin_state.last_failure_time = get_time_ms();
+}
+
+void storage_crypto_set_bricked_for_test(bool bricked) {
+    load_pin_state();
+    pin_state.bricked = bricked ? 1 : 0;
 }
 #endif

--- a/main/storage_crypto.c
+++ b/main/storage_crypto.c
@@ -8,6 +8,7 @@
 #include "secure_element.h"
 #include <mbedtls/gcm.h>
 #include <mbedtls/hkdf.h>
+#include <mbedtls/md.h>
 #include <mbedtls/pkcs5.h>
 #include <mbedtls/sha256.h>
 #include <stdbool.h>
@@ -45,6 +46,12 @@ static uint64_t get_time_ms(void) {
 #define NVS_KEY_BRICKED  "bricked"
 #define NVS_KEY_SALT     "salt"
 #define NVS_KEY_HMAC     "hmac"
+#define NVS_KEY_KDF_VER  "kdfver"
+
+// Storage key derivation scheme. Persisted; absent means legacy (an existing
+// device), so its shares stay decryptable. See [[kdf-version]].
+#define KDF_VERSION_LEGACY 0
+#define KDF_VERSION_PBKDF2 1
 
 #define SE_SLOT_PIN_STATE 0
 #define SE_SLOT_HMAC_KEY  1
@@ -69,6 +76,28 @@ static bool salt_initialized = false;
 static pin_state_t pin_state;
 static bool pin_state_loaded = false;
 static bool se_available = false;
+
+#ifdef UNIT_TEST
+static uint8_t kdf_version_override = KDF_VERSION_LEGACY;
+#endif
+
+// Reads the persisted derivation-scheme marker. Absent (a device provisioned
+// before the marker existed) resolves to legacy so its shares still decrypt.
+static uint8_t get_kdf_version(void) {
+#ifdef UNIT_TEST
+    return kdf_version_override;
+#elif defined(ESP_PLATFORM)
+    uint8_t ver = KDF_VERSION_LEGACY;
+    nvs_handle_t handle;
+    if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) == ESP_OK) {
+        nvs_get_u8(handle, NVS_KEY_KDF_VER, &ver);
+        nvs_close(handle);
+    }
+    return ver;
+#else
+    return KDF_VERSION_LEGACY;
+#endif
+}
 
 static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]);
 
@@ -149,39 +178,13 @@ static int compute_state_hmac(const pin_state_t *state, uint8_t hmac_out[32]) {
         return -1;
     }
 
-    uint8_t ipad[64], opad[64];
-    uint8_t key_padded[64];
-    memset(key_padded, 0, sizeof(key_padded));
-    memcpy(key_padded, secret_key, HMAC_KEY_SIZE);
+    // Library HMAC-SHA256 (identical output to the previous hand-rolled
+    // ipad/opad, verified) so a crypto failure returns an error instead of a
+    // valid-looking MAC over garbage.
+    int ret = mbedtls_md_hmac(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), secret_key,
+                              HMAC_KEY_SIZE, (const uint8_t *)state, PIN_STATE_SIZE, hmac_out);
     secure_memzero(secret_key, sizeof(secret_key));
-
-    for (int i = 0; i < 64; i++) {
-        ipad[i] = key_padded[i] ^ 0x36;
-        opad[i] = key_padded[i] ^ 0x5c;
-    }
-
-    mbedtls_sha256_context ctx;
-    uint8_t inner_hash[32];
-
-    mbedtls_sha256_init(&ctx);
-    mbedtls_sha256_starts(&ctx, 0);
-    mbedtls_sha256_update(&ctx, ipad, 64);
-    mbedtls_sha256_update(&ctx, (const uint8_t *)state, PIN_STATE_SIZE);
-    mbedtls_sha256_finish(&ctx, inner_hash);
-    mbedtls_sha256_free(&ctx);
-
-    mbedtls_sha256_init(&ctx);
-    mbedtls_sha256_starts(&ctx, 0);
-    mbedtls_sha256_update(&ctx, opad, 64);
-    mbedtls_sha256_update(&ctx, inner_hash, 32);
-    mbedtls_sha256_finish(&ctx, hmac_out);
-    mbedtls_sha256_free(&ctx);
-
-    secure_memzero(ipad, sizeof(ipad));
-    secure_memzero(opad, sizeof(opad));
-    secure_memzero(key_padded, sizeof(key_padded));
-    secure_memzero(inner_hash, sizeof(inner_hash));
-    return 0;
+    return (ret == 0) ? 0 : -1;
 }
 
 static void load_pin_state(void) {
@@ -335,12 +338,30 @@ static int init_or_load_salt(void) {
 
 static const uint8_t HKDF_INFO[] = "share-encryption-key";
 
-static int derive_key(const uint8_t *device_id, size_t device_id_len, const uint8_t *pin,
-                      size_t pin_len, uint8_t *key_out) {
-    if (device_id_len > DEVICE_ID_SIZE || !pin || pin_len == 0) {
-        return -1;
-    }
+// Legacy (v0.2.0) key derivation. Kept byte-for-byte so shares written before
+// PBKDF2 was introduced still decrypt. See derive_key() and [[kdf-version]].
+static const uint8_t HKDF_SALT[] = "keep-esp32-share-storage-v1";
 
+static int derive_key_legacy(const uint8_t *device_id, size_t device_id_len, const uint8_t *pin,
+                             size_t pin_len, uint8_t *key_out) {
+    uint8_t ikm[DEVICE_ID_SIZE + STORAGE_CRYPTO_MAX_PIN_LEN];
+    size_t ikm_len = device_id_len;
+    memcpy(ikm, device_id, device_id_len);
+    if (pin && pin_len > 0) {
+        size_t copy_len =
+            pin_len < STORAGE_CRYPTO_MAX_PIN_LEN ? pin_len : STORAGE_CRYPTO_MAX_PIN_LEN;
+        memcpy(ikm + device_id_len, pin, copy_len);
+        ikm_len += copy_len;
+    }
+    int ret = mbedtls_hkdf(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256), HKDF_SALT,
+                           sizeof(HKDF_SALT) - 1, ikm, ikm_len, HKDF_INFO, sizeof(HKDF_INFO) - 1,
+                           key_out, STORAGE_CRYPTO_KEY_SIZE);
+    secure_memzero(ikm, sizeof(ikm));
+    return (ret == 0) ? 0 : -1;
+}
+
+static int derive_key_pbkdf2(const uint8_t *device_id, size_t device_id_len, const uint8_t *pin,
+                             size_t pin_len, uint8_t *key_out) {
     if (init_or_load_salt() != 0) {
         return -1;
     }
@@ -351,8 +372,8 @@ static int derive_key(const uint8_t *device_id, size_t device_id_len, const uint
 
     uint8_t stretched[32];
     int ret = mbedtls_pkcs5_pbkdf2_hmac_ext(MBEDTLS_MD_SHA256, pin, pin_len, pbkdf2_salt,
-                                            sizeof(pbkdf2_salt), PIN_PBKDF2_ITERATIONS,
-                                            sizeof(stretched), stretched);
+                                            PIN_PBKDF2_SALT_LEN + device_id_len,
+                                            PIN_PBKDF2_ITERATIONS, sizeof(stretched), stretched);
     secure_memzero(pbkdf2_salt, sizeof(pbkdf2_salt));
 
     if (ret != 0) {
@@ -366,6 +387,21 @@ static int derive_key(const uint8_t *device_id, size_t device_id_len, const uint
     secure_memzero(stretched, sizeof(stretched));
 
     return (ret == 0) ? 0 : -1;
+}
+
+// [[kdf-version]] The active derivation is chosen by a persisted marker, default
+// legacy so existing devices keep decrypting. PBKDF2 is staged but not yet
+// activated at provisioning time (tracked separately); until then every device
+// derives the proven legacy key.
+static int derive_key(const uint8_t *device_id, size_t device_id_len, const uint8_t *pin,
+                      size_t pin_len, uint8_t *key_out) {
+    if (device_id_len > DEVICE_ID_SIZE || !pin || pin_len == 0) {
+        return -1;
+    }
+    if (get_kdf_version() == KDF_VERSION_PBKDF2) {
+        return derive_key_pbkdf2(device_id, device_id_len, pin, pin_len, key_out);
+    }
+    return derive_key_legacy(device_id, device_id_len, pin, pin_len, key_out);
 }
 
 static uint32_t get_delay_ms(uint8_t attempts) {

--- a/main/storage_crypto.c
+++ b/main/storage_crypto.c
@@ -41,17 +41,19 @@ static uint32_t get_time_ms(void) {
 
 #define NVS_NAMESPACE     "pin_rl"
 #define NVS_KEY_FAILURES  "failures"
-#define NVS_KEY_LAST_FAIL "last_fail"
+#define NVS_KEY_LOCKOUT   "lockout"
 #define NVS_KEY_BRICKED   "bricked"
 #define NVS_KEY_SALT      "salt"
 #define NVS_KEY_HMAC      "hmac"
 
 #define SE_SLOT_PIN_STATE 0
+#define SE_SLOT_HMAC_KEY  1
+#define HMAC_KEY_SIZE     32
 
 typedef struct __attribute__((packed)) {
     uint8_t magic[4];
     uint8_t failed_attempts;
-    uint32_t last_failure_time;
+    uint32_t lockout_deadline;
     uint8_t bricked;
     uint8_t reserved[2];
 } pin_state_t;
@@ -68,12 +70,90 @@ static pin_state_t pin_state;
 static bool pin_state_loaded = false;
 static bool se_available = false;
 
-static void compute_state_hmac(const pin_state_t *state, const uint8_t *device_id,
-                               uint8_t hmac_out[32]) {
+static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]);
+
+static int get_hmac_secret_key(uint8_t key_out[HMAC_KEY_SIZE]) {
+    if (se_available) {
+        uint8_t se_data[SE_SLOT_SIZE];
+        if (se_read_slot(SE_SLOT_HMAC_KEY, se_data, sizeof(se_data)) == SE_OK) {
+            bool key_set = false;
+            for (size_t i = 0; i < HMAC_KEY_SIZE; i++) {
+                if (se_data[i] != 0) {
+                    key_set = true;
+                    break;
+                }
+            }
+            if (key_set) {
+                memcpy(key_out, se_data, HMAC_KEY_SIZE);
+                secure_memzero(se_data, sizeof(se_data));
+                return 0;
+            }
+        }
+        if (rng_fill_checked(key_out, HMAC_KEY_SIZE) != 0) {
+            return -1;
+        }
+        uint8_t se_write_data[SE_SLOT_SIZE];
+        memset(se_write_data, 0, sizeof(se_write_data));
+        memcpy(se_write_data, key_out, HMAC_KEY_SIZE);
+        se_write_slot(SE_SLOT_HMAC_KEY, se_write_data, sizeof(se_write_data));
+        secure_memzero(se_write_data, sizeof(se_write_data));
+        return 0;
+    }
+
+#ifdef ESP_PLATFORM
+    uint8_t serial[SE_SERIAL_SIZE];
+    uint8_t device_id[DEVICE_ID_SIZE];
+    if (get_device_id(device_id) != 0) {
+        return -1;
+    }
+    if (se_get_serial(serial) == SE_OK) {
+        mbedtls_sha256_context ctx;
+        mbedtls_sha256_init(&ctx);
+        mbedtls_sha256_starts(&ctx, 0);
+        mbedtls_sha256_update(&ctx, serial, SE_SERIAL_SIZE);
+        mbedtls_sha256_update(&ctx, device_id, DEVICE_ID_SIZE);
+        mbedtls_sha256_finish(&ctx, key_out);
+        mbedtls_sha256_free(&ctx);
+        secure_memzero(serial, sizeof(serial));
+        secure_memzero(device_id, sizeof(device_id));
+        return 0;
+    }
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, device_id, DEVICE_ID_SIZE);
+    mbedtls_sha256_finish(&ctx, key_out);
+    mbedtls_sha256_free(&ctx);
+    secure_memzero(device_id, sizeof(device_id));
+    return 0;
+#else
+    uint8_t device_id[DEVICE_ID_SIZE];
+    if (get_device_id(device_id) != 0) {
+        return -1;
+    }
+    mbedtls_sha256_context ctx;
+    mbedtls_sha256_init(&ctx);
+    mbedtls_sha256_starts(&ctx, 0);
+    mbedtls_sha256_update(&ctx, device_id, DEVICE_ID_SIZE);
+    mbedtls_sha256_finish(&ctx, key_out);
+    mbedtls_sha256_free(&ctx);
+    secure_memzero(device_id, sizeof(device_id));
+    return 0;
+#endif
+}
+
+static void compute_state_hmac(const pin_state_t *state, uint8_t hmac_out[32]) {
+    uint8_t secret_key[HMAC_KEY_SIZE];
+    if (get_hmac_secret_key(secret_key) != 0) {
+        memset(hmac_out, 0, 32);
+        return;
+    }
+
     uint8_t ipad[64], opad[64];
     uint8_t key_padded[64];
     memset(key_padded, 0, sizeof(key_padded));
-    memcpy(key_padded, device_id, DEVICE_ID_SIZE);
+    memcpy(key_padded, secret_key, HMAC_KEY_SIZE);
+    secure_memzero(secret_key, sizeof(secret_key));
 
     for (int i = 0; i < 64; i++) {
         ipad[i] = key_padded[i] ^ 0x36;
@@ -103,8 +183,6 @@ static void compute_state_hmac(const pin_state_t *state, const uint8_t *device_i
     secure_memzero(inner_hash, sizeof(inner_hash));
 }
 
-static int get_device_id(uint8_t device_id[DEVICE_ID_SIZE]);
-
 static void load_pin_state(void) {
     if (pin_state_loaded) {
         return;
@@ -112,7 +190,7 @@ static void load_pin_state(void) {
 
     memcpy(pin_state.magic, PIN_STATE_MAGIC, 4);
     pin_state.failed_attempts = 0;
-    pin_state.last_failure_time = 0;
+    pin_state.lockout_deadline = 0;
     pin_state.bricked = 0;
     memset(pin_state.reserved, 0, sizeof(pin_state.reserved));
 
@@ -128,34 +206,30 @@ static void load_pin_state(void) {
 #ifdef ESP_PLATFORM
         nvs_handle_t handle;
         if (nvs_open(NVS_NAMESPACE, NVS_READONLY, &handle) == ESP_OK) {
-            uint8_t device_id[DEVICE_ID_SIZE];
-            if (get_device_id(device_id) == 0) {
-                uint8_t failures = 0;
-                uint32_t last_fail = 0;
-                uint8_t bricked = 0;
-                uint8_t stored_hmac[32];
-                size_t hmac_len = sizeof(stored_hmac);
+            uint8_t failures = 0;
+            uint32_t lockout = 0;
+            uint8_t bricked = 0;
+            uint8_t stored_hmac[32];
+            size_t hmac_len = sizeof(stored_hmac);
 
-                nvs_get_u8(handle, NVS_KEY_FAILURES, &failures);
-                nvs_get_u32(handle, NVS_KEY_LAST_FAIL, &last_fail);
-                nvs_get_u8(handle, NVS_KEY_BRICKED, &bricked);
+            nvs_get_u8(handle, NVS_KEY_FAILURES, &failures);
+            nvs_get_u32(handle, NVS_KEY_LOCKOUT, &lockout);
+            nvs_get_u8(handle, NVS_KEY_BRICKED, &bricked);
 
-                pin_state_t temp_state;
-                memcpy(temp_state.magic, PIN_STATE_MAGIC, 4);
-                temp_state.failed_attempts = failures;
-                temp_state.last_failure_time = last_fail;
-                temp_state.bricked = bricked;
-                memset(temp_state.reserved, 0, sizeof(temp_state.reserved));
+            pin_state_t temp_state;
+            memcpy(temp_state.magic, PIN_STATE_MAGIC, 4);
+            temp_state.failed_attempts = failures;
+            temp_state.lockout_deadline = lockout;
+            temp_state.bricked = bricked;
+            memset(temp_state.reserved, 0, sizeof(temp_state.reserved));
 
-                if (nvs_get_blob(handle, NVS_KEY_HMAC, stored_hmac, &hmac_len) == ESP_OK &&
-                    hmac_len == 32) {
-                    uint8_t computed_hmac[32];
-                    compute_state_hmac(&temp_state, device_id, computed_hmac);
-                    if (secure_memcmp(stored_hmac, computed_hmac, 32) == 0) {
-                        memcpy(&pin_state, &temp_state, sizeof(pin_state));
-                    }
+            if (nvs_get_blob(handle, NVS_KEY_HMAC, stored_hmac, &hmac_len) == ESP_OK &&
+                hmac_len == 32) {
+                uint8_t computed_hmac[32];
+                compute_state_hmac(&temp_state, computed_hmac);
+                if (secure_memcmp(stored_hmac, computed_hmac, 32) == 0) {
+                    memcpy(&pin_state, &temp_state, sizeof(pin_state));
                 }
-                secure_memzero(device_id, sizeof(device_id));
             }
             nvs_close(handle);
         }
@@ -175,18 +249,14 @@ static void save_pin_state(void) {
 #ifdef ESP_PLATFORM
         nvs_handle_t handle;
         if (nvs_open(NVS_NAMESPACE, NVS_READWRITE, &handle) == ESP_OK) {
-            uint8_t device_id[DEVICE_ID_SIZE];
-            if (get_device_id(device_id) == 0) {
-                uint8_t hmac[32];
-                compute_state_hmac(&pin_state, device_id, hmac);
+            uint8_t hmac[32];
+            compute_state_hmac(&pin_state, hmac);
 
-                nvs_set_u8(handle, NVS_KEY_FAILURES, pin_state.failed_attempts);
-                nvs_set_u32(handle, NVS_KEY_LAST_FAIL, pin_state.last_failure_time);
-                nvs_set_u8(handle, NVS_KEY_BRICKED, pin_state.bricked);
-                nvs_set_blob(handle, NVS_KEY_HMAC, hmac, sizeof(hmac));
-                nvs_commit(handle);
-                secure_memzero(device_id, sizeof(device_id));
-            }
+            nvs_set_u8(handle, NVS_KEY_FAILURES, pin_state.failed_attempts);
+            nvs_set_u32(handle, NVS_KEY_LOCKOUT, pin_state.lockout_deadline);
+            nvs_set_u8(handle, NVS_KEY_BRICKED, pin_state.bricked);
+            nvs_set_blob(handle, NVS_KEY_HMAC, hmac, sizeof(hmac));
+            nvs_commit(handle);
             nvs_close(handle);
         }
 #endif
@@ -304,7 +374,7 @@ static uint32_t get_delay_ms(uint8_t attempts) {
     if (attempts <= 9) {
         return 60 * 1000;
     }
-    if (attempts <= 12) {
+    if (attempts <= (PIN_MAX_ATTEMPTS - 1)) {
         return 15 * 60 * 1000;
     }
     return UINT32_MAX;
@@ -348,10 +418,9 @@ int storage_crypto_check_rate_limit(void) {
         return ERR_PIN_BRICKED;
     }
 
-    if (delay_ms > 0 && pin_state.last_failure_time > 0) {
+    if (pin_state.lockout_deadline > 0) {
         uint32_t now = get_time_ms();
-        uint32_t elapsed = now - pin_state.last_failure_time;
-        if (elapsed < delay_ms) {
+        if (now < pin_state.lockout_deadline) {
             return ERR_PIN_MUST_WAIT;
         }
     }
@@ -364,12 +433,11 @@ void storage_crypto_record_attempt(bool success) {
 
     if (success) {
         pin_state.failed_attempts = 0;
-        pin_state.last_failure_time = 0;
+        pin_state.lockout_deadline = 0;
     } else {
         if (pin_state.failed_attempts < UINT8_MAX) {
             pin_state.failed_attempts++;
         }
-        pin_state.last_failure_time = get_time_ms();
 
         if (pin_state.failed_attempts >= PIN_MAX_ATTEMPTS) {
             ESP_LOGE(TAG, "Max PIN attempts exceeded - wiping device");
@@ -381,8 +449,11 @@ void storage_crypto_record_attempt(bool success) {
 
         uint32_t delay_ms = get_delay_ms(pin_state.failed_attempts);
         if (delay_ms > 0 && delay_ms != UINT32_MAX) {
+            pin_state.lockout_deadline = get_time_ms() + delay_ms;
             ESP_LOGW(TAG, "PIN attempt %d/%d - next attempt in %lu seconds",
                      pin_state.failed_attempts, PIN_MAX_ATTEMPTS, (unsigned long)(delay_ms / 1000));
+        } else {
+            pin_state.lockout_deadline = 0;
         }
     }
     save_pin_state();
@@ -404,21 +475,15 @@ uint32_t storage_crypto_get_delay_remaining(void) {
         return UINT32_MAX;
     }
 
-    uint32_t delay_ms = get_delay_ms(pin_state.failed_attempts);
-    if (delay_ms == 0 || delay_ms == UINT32_MAX) {
-        return delay_ms;
-    }
-
-    if (pin_state.last_failure_time == 0) {
+    if (pin_state.lockout_deadline == 0) {
         return 0;
     }
 
     uint32_t now = get_time_ms();
-    uint32_t elapsed = now - pin_state.last_failure_time;
-    if (elapsed >= delay_ms) {
+    if (now >= pin_state.lockout_deadline) {
         return 0;
     }
-    return delay_ms - elapsed;
+    return pin_state.lockout_deadline - now;
 }
 
 bool storage_crypto_is_bricked(void) {
@@ -537,7 +602,7 @@ int storage_crypto_decrypt(const uint8_t *ciphertext, size_t ciphertext_len, con
 void storage_crypto_reset_rate_limit(void) {
     memcpy(pin_state.magic, PIN_STATE_MAGIC, 4);
     pin_state.failed_attempts = 0;
-    pin_state.last_failure_time = 0;
+    pin_state.lockout_deadline = 0;
     pin_state.bricked = 0;
     memset(pin_state.reserved, 0, sizeof(pin_state.reserved));
     pin_state_loaded = true;
@@ -548,7 +613,12 @@ void storage_crypto_reset_rate_limit(void) {
 void storage_crypto_set_attempts_for_test(uint8_t attempts) {
     load_pin_state();
     pin_state.failed_attempts = attempts;
-    pin_state.last_failure_time = get_time_ms();
+    uint32_t delay_ms = get_delay_ms(attempts);
+    if (delay_ms > 0 && delay_ms != UINT32_MAX) {
+        pin_state.lockout_deadline = get_time_ms() + delay_ms;
+    } else {
+        pin_state.lockout_deadline = 0;
+    }
 }
 
 void storage_crypto_set_bricked_for_test(bool bricked) {

--- a/main/storage_crypto.h
+++ b/main/storage_crypto.h
@@ -20,6 +20,11 @@ void storage_crypto_clear(void);
 int storage_crypto_check_rate_limit(void);
 void storage_crypto_record_attempt(bool success);
 
+uint8_t storage_crypto_get_attempts(void);
+uint8_t storage_crypto_get_max_attempts(void);
+uint32_t storage_crypto_get_delay_remaining(void);
+bool storage_crypto_is_bricked(void);
+
 int storage_crypto_encrypt(const uint8_t *plaintext, size_t plaintext_len, const uint8_t *aad,
                            size_t aad_len, uint8_t nonce[STORAGE_CRYPTO_NONCE_SIZE],
                            uint8_t *ciphertext, uint8_t tag[STORAGE_CRYPTO_TAG_SIZE]);
@@ -27,5 +32,11 @@ int storage_crypto_encrypt(const uint8_t *plaintext, size_t plaintext_len, const
 int storage_crypto_decrypt(const uint8_t *ciphertext, size_t ciphertext_len, const uint8_t *aad,
                            size_t aad_len, const uint8_t nonce[STORAGE_CRYPTO_NONCE_SIZE],
                            const uint8_t tag[STORAGE_CRYPTO_TAG_SIZE], uint8_t *plaintext);
+
+#ifdef UNIT_TEST
+void storage_crypto_reset_rate_limit(void);
+void storage_crypto_set_attempts_for_test(uint8_t attempts);
+void storage_crypto_set_bricked_for_test(bool bricked);
+#endif
 
 #endif

--- a/main/storage_crypto.h
+++ b/main/storage_crypto.h
@@ -4,6 +4,16 @@
 #ifndef STORAGE_CRYPTO_H
 #define STORAGE_CRYPTO_H
 
+// PIN attempt limiting and key stretching for share storage.
+//
+// Threat-model note: this is a best-effort *online* brute-force limiter. Without
+// a provisioned secure element (or eFUSE-backed secret + secure boot + flash
+// encryption), the attempt counter, its HMAC key, and the storage key all live
+// in flash the attacker controls, so an attacker with flash read/write can reset
+// the counter or brute-force the PIN offline. It is NOT a defense against a
+// physical attacker with flash access. Hardening that requires a hardware root
+// of trust is tracked separately.
+
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -222,12 +222,23 @@ endif()
 
 find_library(MBEDCRYPTO_LIB mbedcrypto)
 if(MBEDCRYPTO_LIB)
-    add_executable(test_pin_attempt_limit test_pin_attempt_limit.c ${MAIN_DIR}/random_utils.c ${MAIN_DIR}/hw_entropy.c ${MAIN_DIR}/error_codes.c)
-    target_include_directories(test_pin_attempt_limit PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/mocks
-        ${MAIN_DIR}
+    # Real mbedtls (SHA-256/HMAC/GCM/HKDF/PBKDF2), NOT the mocks/ stubs, so the
+    # PBKDF2 and HMAC-tamper tests actually exercise crypto. Deliberately avoids
+    # -Imocks (its mbedtls/ stubs would shadow the system headers); crypto_asm
+    # and the pbkdf2 _ext shim are supplied by pin_test_compat.c.
+    add_executable(test_pin_attempt_limit
+        test_pin_attempt_limit.c
+        pin_test_compat.c
+        ${MAIN_DIR}/random_utils.c
+        ${MAIN_DIR}/hw_entropy.c
+        ${MAIN_DIR}/error_codes.c
     )
-    target_compile_definitions(test_pin_attempt_limit PRIVATE NATIVE_TEST=1 UNIT_TEST=1 MOCK_MBEDTLS=1)
+    target_include_directories(test_pin_attempt_limit PRIVATE
+        ${MAIN_DIR}
+        ${CMAKE_CURRENT_LIST_DIR}/../../components/crypto_asm/include
+        ${CMAKE_CURRENT_LIST_DIR}/../../components/secure_element/include
+    )
+    target_compile_definitions(test_pin_attempt_limit PRIVATE NATIVE_TEST=1 UNIT_TEST=1)
     target_link_libraries(test_pin_attempt_limit ${MBEDCRYPTO_LIB})
 else()
     message(STATUS "Skipping test_pin_attempt_limit (mbedtls not found)")

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -219,3 +219,16 @@ if(EXISTS ${CJSON_DIR}/cJSON.c)
         message(STATUS "test_coordinator_race: ThreadSanitizer unavailable")
     endif()
 endif()
+
+find_library(MBEDCRYPTO_LIB mbedcrypto)
+if(MBEDCRYPTO_LIB)
+    add_executable(test_pin_attempt_limit test_pin_attempt_limit.c ${MAIN_DIR}/random_utils.c ${MAIN_DIR}/hw_entropy.c ${MAIN_DIR}/error_codes.c)
+    target_include_directories(test_pin_attempt_limit PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/mocks
+        ${MAIN_DIR}
+    )
+    target_compile_definitions(test_pin_attempt_limit PRIVATE NATIVE_TEST=1 UNIT_TEST=1 MOCK_MBEDTLS=1)
+    target_link_libraries(test_pin_attempt_limit ${MBEDCRYPTO_LIB})
+else()
+    message(STATUS "Skipping test_pin_attempt_limit (mbedtls not found)")
+endif()

--- a/test/native/mocks/crypto_asm.h
+++ b/test/native/mocks/crypto_asm.h
@@ -23,6 +23,10 @@ static inline int ct_compare(const void *a, const void *b, size_t len) {
     return acc;
 }
 
+static inline int secure_memcmp(const void *a, const void *b, size_t len) {
+    return ct_compare(a, b, len);
+}
+
 static inline int ct_is_zero(const void *ptr, size_t len) {
     const uint8_t *p = ptr;
     uint8_t acc = 0;

--- a/test/native/mocks/storage_crypto.h
+++ b/test/native/mocks/storage_crypto.h
@@ -16,6 +16,8 @@
 
 static bool mock_crypto_initialized = true;
 static int mock_rate_limit_result = 0;
+static uint8_t mock_pin_attempts = 0;
+static bool mock_is_bricked = false;
 
 static uint8_t mock_last_encrypt_aad[128];
 static size_t mock_last_encrypt_aad_len = 0;
@@ -37,9 +39,27 @@ static inline void storage_crypto_record_attempt(bool success) {
     (void)success;
 }
 
+static inline uint8_t storage_crypto_get_attempts(void) {
+    return mock_pin_attempts;
+}
+
+static inline uint8_t storage_crypto_get_max_attempts(void) {
+    return 21;
+}
+
+static inline uint32_t storage_crypto_get_delay_remaining(void) {
+    return 0;
+}
+
+static inline bool storage_crypto_is_bricked(void) {
+    return mock_is_bricked;
+}
+
 #ifdef UNIT_TEST
 static inline void storage_crypto_reset_rate_limit(void) {
     mock_rate_limit_result = 0;
+    mock_pin_attempts = 0;
+    mock_is_bricked = false;
 }
 #endif
 

--- a/test/native/mocks/storage_crypto.h
+++ b/test/native/mocks/storage_crypto.h
@@ -35,8 +35,17 @@ static inline int storage_crypto_check_rate_limit(void) {
     return mock_rate_limit_result;
 }
 
+static int mock_record_success_calls = 0;
+static int mock_record_failure_calls = 0;
+
 static inline void storage_crypto_record_attempt(bool success) {
-    (void)success;
+    if (success) {
+        mock_record_success_calls++;
+        mock_pin_attempts = 0;
+    } else {
+        mock_record_failure_calls++;
+        mock_pin_attempts++;
+    }
 }
 
 static inline uint8_t storage_crypto_get_attempts(void) {
@@ -60,6 +69,8 @@ static inline void storage_crypto_reset_rate_limit(void) {
     mock_rate_limit_result = 0;
     mock_pin_attempts = 0;
     mock_is_bricked = false;
+    mock_record_success_calls = 0;
+    mock_record_failure_calls = 0;
 }
 #endif
 

--- a/test/native/pin_test_compat.c
+++ b/test/native/pin_test_compat.c
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: MIT
+
+// Native-only support for test_pin_attempt_limit so it exercises the REAL
+// storage_crypto crypto (SHA-256, HMAC, GCM, HKDF, PBKDF2) instead of stubs.
+//
+//   - crypto_asm is hand-written assembly on device; provide C equivalents here.
+//   - mbedtls_pkcs5_pbkdf2_hmac_ext is mbedtls 3.x (what ESP-IDF ships). Host
+//     mbedtls is often 2.28, which only has the older context-based API, so
+//     bridge to it when the _ext symbol is absent.
+
+#include <stddef.h>
+#include <stdint.h>
+
+void secure_memzero(void *ptr, size_t len) {
+    volatile uint8_t *p = ptr;
+    while (len--)
+        *p++ = 0;
+}
+
+int ct_compare(const void *a, const void *b, size_t len) {
+    const uint8_t *pa = a;
+    const uint8_t *pb = b;
+    uint8_t acc = 0;
+    for (size_t i = 0; i < len; i++)
+        acc |= pa[i] ^ pb[i];
+    return acc;
+}
+
+#include <mbedtls/version.h>
+
+#if MBEDTLS_VERSION_NUMBER < 0x03000000
+#include <mbedtls/md.h>
+#include <mbedtls/pkcs5.h>
+
+int mbedtls_pkcs5_pbkdf2_hmac_ext(mbedtls_md_type_t md_type, const unsigned char *password,
+                                  size_t plen, const unsigned char *salt, size_t slen,
+                                  unsigned int iteration_count, uint32_t key_length,
+                                  unsigned char *output) {
+    mbedtls_md_context_t ctx;
+    mbedtls_md_init(&ctx);
+    int ret = mbedtls_md_setup(&ctx, mbedtls_md_info_from_type(md_type), 1);
+    if (ret == 0) {
+        ret = mbedtls_pkcs5_pbkdf2_hmac(&ctx, password, plen, salt, slen, iteration_count,
+                                        key_length, output);
+    }
+    mbedtls_md_free(&ctx);
+    return ret;
+}
+#endif

--- a/test/native/test_pin_attempt_limit.c
+++ b/test/native/test_pin_attempt_limit.c
@@ -258,18 +258,73 @@ static int test_se_persistence(void) {
     return 0;
 }
 
-#ifndef MOCK_MBEDTLS
 static int test_pbkdf2_key_derivation(void) {
     TEST("PBKDF2 key derivation completes");
     reset_test_state();
     salt_initialized = false;
+    kdf_version_override = KDF_VERSION_PBKDF2;
 
     uint8_t device_id[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     uint8_t key[32];
 
     int ret = derive_key(device_id, sizeof(device_id), (const uint8_t *)"testpin", 7, key);
+    kdf_version_override = KDF_VERSION_LEGACY;
     if (ret != 0)
         FAIL("PBKDF2 key derivation should succeed");
+
+    PASS();
+    return 0;
+}
+
+// Migration guard: the default (legacy) derivation must stay byte-for-byte
+// identical to the v0.2.0 scheme, or existing devices' shares stop decrypting.
+static int test_legacy_derivation_is_stable(void) {
+    TEST("legacy key derivation matches v0.2.0");
+    reset_test_state();
+    kdf_version_override = KDF_VERSION_LEGACY;
+
+    uint8_t device_id[6] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66};
+    uint8_t key[32];
+    if (derive_key(device_id, sizeof(device_id), (const uint8_t *)"1234", 4, key) != 0)
+        FAIL("legacy derivation should succeed");
+
+    // Independently recomputed golden vector: HKDF-SHA256(
+    //   salt="keep-esp32-share-storage-v1", ikm=device_id||"1234",
+    //   info="share-encryption-key").
+    uint8_t expected[32];
+    mbedtls_hkdf(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256),
+                 (const uint8_t *)"keep-esp32-share-storage-v1", 27,
+                 (const uint8_t *)"\x11\x22\x33\x44\x55\x66"
+                                  "1234",
+                 10, (const uint8_t *)"share-encryption-key", 20, expected, 32);
+    if (memcmp(key, expected, 32) != 0)
+        FAIL("legacy key drifted from v0.2.0 derivation");
+
+    PASS();
+    return 0;
+}
+
+// The KDF-version marker must actually switch derivations, so a device on one
+// scheme never silently produces the other's key.
+static int test_kdf_marker_switches_derivation(void) {
+    TEST("KDF marker selects derivation");
+    reset_test_state();
+
+    uint8_t device_id[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    uint8_t legacy_key[32], pbkdf2_key[32];
+
+    kdf_version_override = KDF_VERSION_LEGACY;
+    if (derive_key(device_id, sizeof(device_id), (const uint8_t *)"testpin", 7, legacy_key) != 0)
+        FAIL("legacy derivation should succeed");
+
+    salt_initialized = false;
+    kdf_version_override = KDF_VERSION_PBKDF2;
+    if (derive_key(device_id, sizeof(device_id), (const uint8_t *)"testpin", 7, pbkdf2_key) != 0)
+        FAIL("pbkdf2 derivation should succeed");
+    kdf_version_override = KDF_VERSION_LEGACY;
+
+    if (memcmp(legacy_key, pbkdf2_key, 32) == 0)
+        FAIL("legacy and pbkdf2 must produce different keys");
 
     PASS();
     return 0;
@@ -302,7 +357,6 @@ static int test_hmac_tamper_detection(void) {
     PASS();
     return 0;
 }
-#endif
 
 static int test_attempt_overflow_protection(void) {
     TEST("attempt counter overflow protection");
@@ -336,12 +390,10 @@ int main(void) {
     failures += test_max_attempts_getter();
     failures += test_delay_remaining();
     failures += test_se_persistence();
-#ifndef MOCK_MBEDTLS
     failures += test_pbkdf2_key_derivation();
+    failures += test_legacy_derivation_is_stable();
+    failures += test_kdf_marker_switches_derivation();
     failures += test_hmac_tamper_detection();
-#else
-    printf("  SKIPPED: PBKDF2 and HMAC tests (mocked mbedtls)\n");
-#endif
     failures += test_attempt_overflow_protection();
 
     printf("\n");

--- a/test/native/test_pin_attempt_limit.c
+++ b/test/native/test_pin_attempt_limit.c
@@ -1,0 +1,350 @@
+// SPDX-FileCopyrightText: © 2026 PrivKey LLC
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <time.h>
+
+#define SECURE_ELEMENT_H
+#define MOCK_SECURE_ELEMENT_H
+#define SE_SLOT_COUNT  16
+#define SE_SLOT_SIZE   72
+#define SE_SERIAL_SIZE 9
+
+typedef enum {
+    SE_OK = 0,
+    SE_ERR_INVALID_PARAM = -1,
+    SE_ERR_NOT_PROVISIONED = -2,
+    SE_ERR_COMM_FAIL = -3,
+    SE_ERR_LOCKED = -4,
+    SE_ERR_NOT_INITIALIZED = -5
+} se_status_t;
+
+static uint8_t mock_se_slots[SE_SLOT_COUNT][SE_SLOT_SIZE];
+static bool mock_se_available = false;
+
+se_status_t se_init(void) {
+    if (mock_se_available) {
+        return SE_OK;
+    }
+    return SE_ERR_NOT_PROVISIONED;
+}
+
+bool se_is_provisioned(void) {
+    return mock_se_available;
+}
+
+se_status_t se_read_slot(uint8_t slot, uint8_t *data, size_t len) {
+    if (!mock_se_available) {
+        return SE_ERR_NOT_PROVISIONED;
+    }
+    if (slot >= SE_SLOT_COUNT || !data || len > SE_SLOT_SIZE) {
+        return SE_ERR_INVALID_PARAM;
+    }
+    memcpy(data, mock_se_slots[slot], len);
+    return SE_OK;
+}
+
+se_status_t se_write_slot(uint8_t slot, const uint8_t *data, size_t len) {
+    if (!mock_se_available) {
+        return SE_ERR_NOT_PROVISIONED;
+    }
+    if (slot >= SE_SLOT_COUNT || !data || len > SE_SLOT_SIZE) {
+        return SE_ERR_INVALID_PARAM;
+    }
+    memcpy(mock_se_slots[slot], data, len);
+    return SE_OK;
+}
+
+se_status_t se_increment_counter(uint32_t *new_value) {
+    (void)new_value;
+    return SE_ERR_NOT_PROVISIONED;
+}
+
+se_status_t se_get_counter(uint32_t *value) {
+    (void)value;
+    return SE_ERR_NOT_PROVISIONED;
+}
+
+se_status_t se_get_serial(uint8_t serial[SE_SERIAL_SIZE]) {
+    (void)serial;
+    return SE_ERR_NOT_PROVISIONED;
+}
+
+#define UNIT_TEST 1
+
+#define STORAGE_CRYPTO_H
+#define STORAGE_CRYPTO_KEY_SIZE    32
+#define STORAGE_CRYPTO_NONCE_SIZE  12
+#define STORAGE_CRYPTO_TAG_SIZE    16
+#define STORAGE_CRYPTO_MAX_PIN_LEN 64
+
+#include "crypto_asm.h"
+#include "random_utils.h"
+#include "error_codes.h"
+
+#include "storage_crypto.c"
+
+#define TEST(name) printf("  TEST: %s\n", name)
+#define PASS()     printf("    PASS\n")
+#define FAIL(msg)                      \
+    do {                               \
+        printf("    FAIL: %s\n", msg); \
+        return 1;                      \
+    } while (0)
+
+static void reset_test_state(void) {
+    storage_crypto_reset_rate_limit();
+    memset(mock_se_slots, 0, sizeof(mock_se_slots));
+    mock_se_available = false;
+}
+
+static int test_initial_state(void) {
+    TEST("initial state allows PIN attempts");
+    reset_test_state();
+
+    if (storage_crypto_check_rate_limit() != 0)
+        FAIL("initial state should allow attempts");
+    if (storage_crypto_get_attempts() != 0)
+        FAIL("initial attempts should be 0");
+    if (storage_crypto_is_bricked())
+        FAIL("should not be bricked initially");
+
+    PASS();
+    return 0;
+}
+
+static int test_delay_schedule(void) {
+    TEST("exponential delay schedule");
+    reset_test_state();
+
+    if (get_delay_ms(0) != 0)
+        FAIL("0 attempts should have no delay");
+    if (get_delay_ms(3) != 0)
+        FAIL("3 attempts should have no delay");
+    if (get_delay_ms(4) != 15000)
+        FAIL("4 attempts should have 15s delay");
+    if (get_delay_ms(6) != 15000)
+        FAIL("6 attempts should have 15s delay");
+    if (get_delay_ms(7) != 60000)
+        FAIL("7 attempts should have 1min delay");
+    if (get_delay_ms(9) != 60000)
+        FAIL("9 attempts should have 1min delay");
+    if (get_delay_ms(10) != 900000)
+        FAIL("10 attempts should have 15min delay");
+    if (get_delay_ms(12) != 900000)
+        FAIL("12 attempts should have 15min delay");
+    if (get_delay_ms(13) != UINT32_MAX)
+        FAIL("13+ attempts should return max delay (bricked)");
+
+    PASS();
+    return 0;
+}
+
+static int test_attempt_tracking(void) {
+    TEST("failed attempt tracking");
+    reset_test_state();
+
+    storage_crypto_record_attempt(false);
+    if (storage_crypto_get_attempts() != 1)
+        FAIL("should have 1 attempt");
+
+    storage_crypto_record_attempt(false);
+    storage_crypto_record_attempt(false);
+    if (storage_crypto_get_attempts() != 3)
+        FAIL("should have 3 attempts");
+
+    PASS();
+    return 0;
+}
+
+static int test_success_resets_counter(void) {
+    TEST("successful attempt resets counter");
+    reset_test_state();
+
+    for (int i = 0; i < 5; i++) {
+        storage_crypto_record_attempt(false);
+    }
+    if (storage_crypto_get_attempts() != 5)
+        FAIL("should have 5 attempts");
+
+    storage_crypto_record_attempt(true);
+    if (storage_crypto_get_attempts() != 0)
+        FAIL("success should reset counter to 0");
+
+    PASS();
+    return 0;
+}
+
+static int test_bricking_after_max_attempts(void) {
+    TEST("device bricks after max attempts");
+    reset_test_state();
+
+    for (int i = 0; i < 20; i++) {
+        storage_crypto_record_attempt(false);
+    }
+    if (storage_crypto_is_bricked())
+        FAIL("should not be bricked at 20 attempts");
+
+    storage_crypto_record_attempt(false);
+    if (!storage_crypto_is_bricked())
+        FAIL("should be bricked at 21 attempts");
+
+    PASS();
+    return 0;
+}
+
+static int test_bricked_device_rejects_attempts(void) {
+    TEST("bricked device rejects all PIN attempts");
+    reset_test_state();
+
+    storage_crypto_set_bricked_for_test(true);
+
+    if (storage_crypto_check_rate_limit() != ERR_PIN_BRICKED)
+        FAIL("bricked device should return ERR_PIN_BRICKED");
+    if (storage_crypto_init("1234") != ERR_PIN_BRICKED)
+        FAIL("bricked device should reject PIN init");
+
+    PASS();
+    return 0;
+}
+
+static int test_max_attempts_getter(void) {
+    TEST("max attempts getter returns correct value");
+    reset_test_state();
+
+    if (storage_crypto_get_max_attempts() != 21)
+        FAIL("max attempts should be 21");
+
+    PASS();
+    return 0;
+}
+
+static int test_delay_remaining(void) {
+    TEST("delay remaining calculation");
+    reset_test_state();
+
+    storage_crypto_set_attempts_for_test(5);
+
+    uint32_t delay = storage_crypto_get_delay_remaining();
+    if (delay == 0)
+        FAIL("should have delay remaining after 5 failed attempts");
+    if (delay > 15000)
+        FAIL("delay should not exceed 15s for 5 attempts");
+
+    PASS();
+    return 0;
+}
+
+static int test_se_persistence(void) {
+    TEST("SE-based state persistence");
+    reset_test_state();
+    mock_se_available = true;
+    pin_state_loaded = false;
+
+    storage_crypto_record_attempt(false);
+    storage_crypto_record_attempt(false);
+
+    if (memcmp(mock_se_slots[0], "PIN", 3) != 0)
+        FAIL("SE slot should contain PIN magic");
+
+    PASS();
+    return 0;
+}
+
+#ifndef MOCK_MBEDTLS
+static int test_pbkdf2_key_derivation(void) {
+    TEST("PBKDF2 key derivation completes");
+    reset_test_state();
+    salt_initialized = false;
+
+    uint8_t device_id[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    uint8_t key[32];
+
+    int ret = derive_key(device_id, sizeof(device_id), (const uint8_t *)"testpin", 7, key);
+    if (ret != 0)
+        FAIL("PBKDF2 key derivation should succeed");
+
+    PASS();
+    return 0;
+}
+
+static int test_hmac_tamper_detection(void) {
+    TEST("HMAC detects state tampering");
+    reset_test_state();
+
+    pin_state_t state1, state2;
+    memcpy(state1.magic, "PIN\0", 4);
+    state1.failed_attempts = 5;
+    state1.last_failure_time = 12345;
+    state1.bricked = 0;
+    memset(state1.reserved, 0, sizeof(state1.reserved));
+
+    memcpy(&state2, &state1, sizeof(state1));
+    state2.failed_attempts = 0;
+
+    uint8_t device_id[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
+    uint8_t hmac1[32], hmac2[32];
+
+    compute_state_hmac(&state1, device_id, hmac1);
+    compute_state_hmac(&state2, device_id, hmac2);
+
+    if (memcmp(hmac1, hmac2, 32) == 0)
+        FAIL("different states should produce different HMACs");
+
+    PASS();
+    return 0;
+}
+#endif
+
+static int test_attempt_overflow_protection(void) {
+    TEST("attempt counter overflow protection");
+    reset_test_state();
+
+    pin_state.failed_attempts = 254;
+    pin_state_loaded = true;
+
+    storage_crypto_record_attempt(false);
+    if (pin_state.failed_attempts != 255)
+        FAIL("should increment to 255");
+
+    storage_crypto_record_attempt(false);
+    if (pin_state.failed_attempts != 255)
+        FAIL("should stay at 255 (no overflow)");
+
+    PASS();
+    return 0;
+}
+
+int main(void) {
+    printf("\n=== PIN Attempt Limiting Tests ===\n\n");
+
+    int failures = 0;
+    failures += test_initial_state();
+    failures += test_delay_schedule();
+    failures += test_attempt_tracking();
+    failures += test_success_resets_counter();
+    failures += test_bricking_after_max_attempts();
+    failures += test_bricked_device_rejects_attempts();
+    failures += test_max_attempts_getter();
+    failures += test_delay_remaining();
+    failures += test_se_persistence();
+#ifndef MOCK_MBEDTLS
+    failures += test_pbkdf2_key_derivation();
+    failures += test_hmac_tamper_detection();
+#else
+    printf("  SKIPPED: PBKDF2 and HMAC tests (mocked mbedtls)\n");
+#endif
+    failures += test_attempt_overflow_protection();
+
+    printf("\n");
+    if (failures == 0) {
+        printf("=== All tests passed ===\n\n");
+        return 0;
+    } else {
+        printf("=== %d test(s) failed ===\n\n", failures);
+        return 1;
+    }
+}

--- a/test/native/test_pin_attempt_limit.c
+++ b/test/native/test_pin_attempt_limit.c
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: © 2026 PrivKey LLC
-// SPDX-License-Identifier: AGPL-3.0-or-later
+// SPDX-License-Identifier: MIT
 
 #include <stdio.h>
 #include <string.h>

--- a/test/native/test_pin_attempt_limit.c
+++ b/test/native/test_pin_attempt_limit.c
@@ -136,8 +136,12 @@ static int test_delay_schedule(void) {
         FAIL("10 attempts should have 15min delay");
     if (get_delay_ms(12) != 900000)
         FAIL("12 attempts should have 15min delay");
-    if (get_delay_ms(13) != UINT32_MAX)
-        FAIL("13+ attempts should return max delay (bricked)");
+    if (get_delay_ms(13) != 900000)
+        FAIL("13 attempts should have 15min delay");
+    if (get_delay_ms(20) != 900000)
+        FAIL("20 attempts should have 15min delay");
+    if (get_delay_ms(21) != UINT32_MAX)
+        FAIL("21 attempts should return max delay (bricked)");
 
     PASS();
     return 0;
@@ -278,18 +282,19 @@ static int test_hmac_tamper_detection(void) {
     pin_state_t state1, state2;
     memcpy(state1.magic, "PIN\0", 4);
     state1.failed_attempts = 5;
-    state1.last_failure_time = 12345;
+    state1.lockout_deadline = 12345;
     state1.bricked = 0;
     memset(state1.reserved, 0, sizeof(state1.reserved));
 
     memcpy(&state2, &state1, sizeof(state1));
     state2.failed_attempts = 0;
 
-    uint8_t device_id[6] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06};
     uint8_t hmac1[32], hmac2[32];
 
-    compute_state_hmac(&state1, device_id, hmac1);
-    compute_state_hmac(&state2, device_id, hmac2);
+    if (compute_state_hmac(&state1, hmac1) != 0)
+        FAIL("compute_state_hmac should succeed for state1");
+    if (compute_state_hmac(&state2, hmac2) != 0)
+        FAIL("compute_state_hmac should succeed for state2");
 
     if (memcmp(hmac1, hmac2, 32) == 0)
         FAIL("different states should produce different HMACs");

--- a/test/native/test_storage.c
+++ b/test/native/test_storage.c
@@ -133,6 +133,37 @@ static int test_init_no_partition(void) {
     return 0;
 }
 
+static int test_successful_load_resets_pin_attempts(void) {
+    TEST("successful share load records a PIN success");
+    reset_flash();
+    if (storage_init() != 0)
+        FAIL("init failed");
+
+    if (storage_save_share("grp", "deadbeef") != 0)
+        FAIL("save failed");
+
+    // Simulate a couple of prior mistypes accumulated on this device.
+    storage_crypto_record_attempt(false);
+    storage_crypto_record_attempt(false);
+    if (storage_crypto_get_attempts() != 2)
+        FAIL("precondition: 2 failed attempts");
+
+    char loaded[128];
+    mock_record_success_calls = 0;
+    if (storage_load_share("grp", loaded, sizeof(loaded)) != 0)
+        FAIL("load failed");
+
+    // The good decrypt must be recorded as a success, clearing the counter.
+    // Without it, failed_attempts only ever climbs toward the brick threshold.
+    if (mock_record_success_calls != 1)
+        FAIL("successful load must record a PIN success");
+    if (storage_crypto_get_attempts() != 0)
+        FAIL("success must reset the failed-attempt counter");
+
+    PASS();
+    return 0;
+}
+
 static int test_save_load_roundtrip(void) {
     TEST("save/load roundtrip");
     reset_flash();
@@ -901,6 +932,7 @@ int main(void) {
     failures += test_init();
     failures += test_init_no_partition();
     failures += test_save_load_roundtrip();
+    failures += test_successful_load_resets_pin_attempts();
     failures += test_save_overwrite();
     failures += test_delete();
     failures += test_delete_nonexistent();


### PR DESCRIPTION
## Summary

Adds a PIN attempt limiter for share storage: a persisted failure counter, a progressive lockout schedule (15s / 1min / 15min), and a device brick after 21 consecutive failures that clears the in-RAM key and NVS key material, with HMAC-protected state. Also lands the PBKDF2 key-stretching plumbing, staged (see Scope below).

Partially addresses #68 (attempt limiting lands active; key stretching is staged, see Scope).

## Scope and threat model

This is a best-effort **online** brute-force limiter. It is **not** a defense against a physical attacker with flash read/write access, and the code and header now say so plainly.

On shipping hardware the secure element is a not-provisioned stub, so the counter, its HMAC key, and the storage key all live in flash the attacker controls. An attacker with flash access can reset the counter or brute-force the PIN offline regardless of the online limit. Making this a real control requires a hardware root of trust (SE-held secret or eFUSE key + secure boot + flash encryption) backing both the storage key and a monotonic counter. That work, plus fail-closed-on-erased-state and write-ahead counter persistence, is tracked as follow-up issues (#141, #142) rather than claimed here.

Also note the brick path clears the in-RAM key and the NVS key material but does **not** erase the encrypted shares from their storage partition, so it is not a full data wipe. Whether brick should irreversibly erase the share partition is deliberately left as a separate decision (tracked as a follow-up) rather than bolted onto this PR.

## Fixes over the initial revision

- **Self-brick (fund loss):** a successful decrypt never reset the failure counter, so a user who occasionally mistyped would march toward the 21-attempt brick with no way to recover. `storage_load_share` now records a success (resetting the counter) on a good decrypt. Covered by a new `test_storage` case.
- **Data loss on upgrade:** the key derivation changed from the shipped v0.2.0 HKDF scheme to PBKDF2 with no version gate, which would make every existing device's shares undecryptable. Derivation now selects on a persisted `kdf_version` marker that defaults to legacy, so existing devices keep decrypting. The legacy path is re-added byte-for-byte and pinned by a golden-vector test. PBKDF2 is present but not yet activated at provisioning time (staged, tracked separately) — no device silently changes keys.
- **HMAC fail-open:** `compute_state_hmac` ignored the SHA-256 return codes and could return a valid-looking MAC over garbage. Replaced the hand-rolled ipad/opad with `mbedtls_md_hmac` (verified byte-identical, so stored HMACs still validate) which returns an error that both callers handle.
- **Bricked state surfaced as a generic "Unlock failed";** now mapped to `ERR_PIN_BRICKED`.

## Test coverage (this was the biggest gap)

The suite was built but **never executed** (absent from CI's native-test list and the Justfile), and `MOCK_MBEDTLS` compiled out the only two crypto tests while the mocks stubbed SHA-256 to a constant, so PBKDF2 and HMAC tamper detection were never actually exercised.

- `test_pin_attempt_limit` now builds and runs against **real** mbedtls (SHA-256 / HMAC / GCM / HKDF / PBKDF2) via `pin_test_compat.c`, which supplies the native `crypto_asm` primitives and an `mbedtls_pkcs5_pbkdf2_hmac_ext` shim for host mbedtls < 3.x. `MOCK_MBEDTLS` and the stub path are gone.
- Wired into CI (`libmbedtls-dev` added; the binary is run) and `just test`.
- New tests: legacy-derivation golden vector (migration safety), KDF-marker-switches-derivation, and successful-load-resets-attempts. Each fix was mutation-tested — the bug was reintroduced and the corresponding test confirmed to fail.

## Verification

- `just test` — full native suite passes, including the real-crypto PIN tests
- `cppcheck`, `clang-format` — clean
- `idf.py build` for esp32s3 — clean, no warnings (this module is linked into the firmware)
