### PR TITLE
Bump to v0.2.1 so a fixed build is identifiable

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -16,6 +16,21 @@ Key material goes through `rng_fill_checked()`, which draws from `hw_entropy_fil
 
 Nothing in this firmware may enable Wi-Fi, Bluetooth, I2S, the ADC driver, or light/deep sleep without first resolving the conflict with the entropy source: they all take back the SAR ADC or the RTC state it configures. `scripts/check-rng-hygiene.sh` rejects each of them, along with a missing, duplicated, compiled-out, or relocated `bootloader_random_enable()`, any `bootloader_random_disable()`, raw HWRNG draws outside the entropy module, and libc `rand()`. Its limits are stated in its header; most importantly it is a grep, it sees only this repo and not the sibling component checkouts, and it cannot confirm the SAR ADC is producing noise on real silicon.
 
+### Telling a fixed device from a vulnerable one
+
+Every release up to and including v0.2.0 shipped without the entropy source enabled. The firmware version alone does not distinguish them: builds from `main` between the v0.2.0 tag and the fix also report `0.2.0`. Use the RPC field, which only exists on fixed firmware:
+
+```console
+$ keep-esp32-rpc get_status
+{"version":"0.2.1","rng_healthy":true,"rng_entropy_source":true, ...}
+```
+
+- `rng_entropy_source` **absent** — pre-fix firmware. The RNG ran without a continuous entropy source.
+- `rng_entropy_source: false` — fixed firmware, but the SAR ADC entropy path did not come up. Do not provision; the boot log carries `Entropy source did not come up`.
+- `rng_entropy_source: true` — the entropy source is running.
+
+Note that `rng_healthy`, `self_test_ok` and `rng_failed_checks` stay green in all three cases. They are statistical checks, and a seeded PRNG passes statistical checks; that is the whole reason `rng_entropy_source` exists. This was confirmed on hardware in both directions.
+
 **Devices provisioned before this change.** Firmware built before the entropy source was enabled generated its storage HMAC key, PIN salt, and any on-device FROST share from an RNG that Espressif does not guarantee to be a true RNG. That material is not rotated by a firmware update. Anyone holding such a device should re-provision it rather than assume the update fixed key material already on flash.
 
 ## Threshold Signing

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,11 +1,14 @@
 {
   "name": "Keep FROST Signer",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "builds": [
     {
       "chipFamily": "ESP32-S3",
       "parts": [
-        { "path": "keep-merged.bin", "offset": 0 }
+        {
+          "path": "keep-merged.bin",
+          "offset": 0
+        }
       ]
     }
   ]

--- a/main/main.c
+++ b/main/main.c
@@ -25,7 +25,7 @@
 #include "self_test.h"
 
 #define TAG                  "main"
-#define VERSION              "0.2.0"
+#define VERSION              "0.2.1"
 #define RATE_LIMIT_THRESHOLD 5
 #define RATE_LIMIT_DELAY_MS  1000
 


### PR DESCRIPTION
## Summary
- Bumps `VERSION` to `0.2.1` and the web-flasher manifest to match, so a build containing the RNG fix (#144) can be told apart from one without it.
- Adds operator guidance to `docs/SECURITY.md` for deciding which firmware a device is running.

## Why this is not routine version housekeeping

Every published release — v0.1.0, v0.1.1, v0.1.2, v0.2.0 — predates #144. `git merge-base --is-ancestor 7b61fec v0.2.0` is false; v0.2.0 was tagged 2026-02-16 and the fix merged 2026-07-31. So every released build ran the hardware RNG without a continuous entropy source.

The problem this PR fixes is that **an operator could not tell which build they had.** `main/main.c` still carried `VERSION "0.2.0"` after the fix, identical to the vulnerable released v0.2.0. Confirmed on hardware: a board flashed from fixed `main` reported `{"version":"0.2.0"}` while its ELF was `v0.2.0-5-g7b61fec`. Same string, opposite security posture.

`docs/manifest.json` was separately stale at `0.1.2` — it never got bumped for the v0.2.0 release either, so the web flasher has been mislabelling builds for two releases.

## What an operator should check

`rng_entropy_source` is the reliable discriminator, and it is now documented:

- **absent** — pre-fix firmware
- **`false`** — fixed firmware, entropy path did not come up; do not provision
- **`true`** — entropy source running

The doc also states plainly that `rng_healthy`, `self_test_ok` and `rng_failed_checks` stay green in all three cases. They are statistical checks and a seeded PRNG passes statistical checks. That was verified on hardware in both directions (see the hardware-verification comment on #144), and it is exactly why the new field had to exist.

## Not in this PR

- **Disclosure.** Prior releases generated FROST shares, storage HMAC keys and PIN salts from a degraded source, and flashing new firmware does not rotate key material already on flash. Holders need to re-provision. That is outward-facing and needs a human decision on wording and on whether it warrants a GitHub Security Advisory; tracked in `hq-prk`.
- `PROTOCOL_VERSION` in `main/protocol.h:17` is a second `"0.2.0"` string that nothing references (`PROTOCOL_API_VERSION`, an integer, is what `ping` actually reports). Left alone deliberately rather than bumped, since bumping a dead duplicate of the firmware version would make it look like a wire-protocol change.

## Test plan
- [x] `idf.py build` (ESP-IDF v5.4.1, esp32s3): BUILD SUCCEEDED
- [x] Native suite green (`just test`, exit 0)
- [x] `scripts/check-rng-hygiene.sh` exits 0; `docs/manifest.json` parses as JSON
- [x] **Flashed to an M5Stack CoreS3 and verified on hardware**: `ping` and `get_status` both report `"version":"0.2.1"`, with `"rng_entropy_source":true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for identifying vulnerable and fixed firmware through the `get_status` response.
  * Clarified entropy-source status values and noted that statistical health indicators may not reveal affected devices.
  * Advised re-provisioning devices provisioned before the entropy-source fix.

* **Chores**
  * Updated the firmware version to 0.2.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->