### PR TITLE
Pin every upstream dependency by commit and update libwally to 1.5.6

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+# The reproducible build must not depend on the host working tree. Without this,
+# `docker build .` copies whatever is lying around into the context: a local
+# build/ directory makes the image build fail outright with
+#   Directory '/build/keep-esp32/build' doesn't seem to be a CMake build directory
+# and anything else stray would silently become a build input.
+build/
+output/
+managed_components/
+sdkconfig.old
+test/native/build/
+fuzz/build/
+.git/
+.beads/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,25 +18,27 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/secp256k1-frost
-          ref: esp-idf-support
+          # Pinned by commit, not branch: a branch ref means anyone with push
+          # access silently changes what CI builds and what we release.
+          ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/libnostr-c
-          ref: v0.1.5
+          ref: 724868d508d5fa02f11d6e9549a225c60a4132e1 # v0.1.5
           path: libnostr-c
 
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/noscrypt
-          ref: esp-idf-support
+          ref: 45fcbef32f958145d6797f384a225c0d43616886
           path: noscrypt
 
       - uses: actions/checkout@v4
         with:
           repository: ElementsProject/libwally-core
-          ref: release_1.5.1
+          ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
           path: libwally-core
 
       - uses: espressif/esp-idf-ci-action@v1
@@ -56,13 +58,15 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/secp256k1-frost
-          ref: esp-idf-support
+          # Pinned by commit, not branch: a branch ref means anyone with push
+          # access silently changes what CI builds and what we release.
+          ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
       - uses: actions/checkout@v4
         with:
           repository: ElementsProject/libwally-core
-          ref: release_1.5.1
+          ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
           path: libwally-core
           submodules: recursive
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,25 +22,27 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/secp256k1-frost
-          ref: esp-idf-support
+          # Pinned by commit, not branch: a branch ref means anyone with push
+          # access silently changes what CI builds and what we release.
+          ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/libnostr-c
-          ref: v0.1.5
+          ref: 724868d508d5fa02f11d6e9549a225c60a4132e1 # v0.1.5
           path: libnostr-c
 
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/noscrypt
-          ref: esp-idf-support
+          ref: 45fcbef32f958145d6797f384a225c0d43616886
           path: noscrypt
 
       - uses: actions/checkout@v4
         with:
           repository: ElementsProject/libwally-core
-          ref: release_1.5.1
+          ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
           path: libwally-core
 
       - name: Build ESP32-S3 firmware

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -14,10 +14,10 @@ WORKDIR /build
 COPY . keep-esp32/
 
 RUN for repo in \
-        "privkeyio/secp256k1-frost 832bac2dbfaf4c35058cd5dadb0f8fe093cb6c65" \
-        "privkeyio/libnostr-c 4e8d01b8d20680204429aaf3680d069ec222fdaa" \
+        "privkeyio/secp256k1-frost 746dbbea5c34dde963c9bd55bc7474b2d50fa597" \
+        "privkeyio/libnostr-c 724868d508d5fa02f11d6e9549a225c60a4132e1" \
         "privkeyio/noscrypt 45fcbef32f958145d6797f384a225c0d43616886" \
-        "ElementsProject/libwally-core 242f841af6819b5d5174da5a9593907f56f1bc89"; do \
+        "ElementsProject/libwally-core 0c41f38fb1c201786e9c3ac9eae4f5f80c051399"; do \
         set -- $repo; \
         git clone "https://github.com/$1.git" && \
         git -C "$(basename $1)" checkout "$2"; \


### PR DESCRIPTION
## Summary
- Pins **every** upstream dependency by commit SHA, in `Dockerfile.reproducible` and in both workflows, and makes the three sources agree byte-for-byte.
- Updates **libwally-core 1.5.1 → 1.5.6**, five releases of security-relevant fixes on a code path that parses attacker-supplied input.
- Fixes `Dockerfile.reproducible`, which did not build at all.
- Adds `.dockerignore` so the reproducible build stops ingesting the host working tree.

## The dependency update

Every libwally release from 1.5.2 onward carries **"This release contains important bug fixes. Users are advised to update as soon as possible."** The ones that matter here:

- **1.5.2** — `psbt: Fix merkle path, witness and buffer length checks when parsing`
- **1.5.3** — `tx: Reject non-corresponding output as per bip341 when signing`; `tx: Avoid quadratic behaviour parsing txs with a huge number of witnesses`
- **1.5.6** — de-optimise memcpy to prevent leaks via extended registers; descriptor input validation

This firmware is exposed to those. `main/psbt.c` calls `wally_psbt_from_base64` on an 8 KB PSBT supplied over the serial RPC (`PROTOCOL_MAX_PSBT_LEN`), then `wally_psbt_get_input_signature_hash` and `wally_psbt_input_set_taproot_signature`. PSBT parse-hardening and a BIP-341 signing correctness fix land directly on the untrusted-input path of a Taproot threshold signer.

## The pinning change, which matters as much

`ci.yml` and `release.yml` checked out **`secp256k1-frost` and `noscrypt` by branch name** (`esp-idf-support`). A branch ref is not a pin: anyone with push access to those forks silently changes what CI builds and what gets released, with no diff in this repo and no review here. `libnostr-c` was taken by tag, which is better but still force-movable.

All four are now commit SHAs, with the human-readable ref in a trailing comment. The Dockerfile and both workflows now name the identical commit for each dependency — previously they did not, see below.

## The reproducible build was broken

`Dockerfile.reproducible` pinned `secp256k1-frost` to `832bac2`, which is **not an ancestor of the `esp-idf-support` branch CI builds**. Both commits are titled "Add ESP-IDF component support"; `832bac2` is a stale rebased twin. The result was not a silent mismatch, it was a hard failure:

```
/build/secp256k1-frost/src/modules/frost/fill_random.h:39:2: error: #error "Couldn't identify the OS"
```

So `just docker-build` — and therefore `just verify-release`, which `README.md` and `docs/REPRODUCIBILITY.md` both tell users to run — could not be executed at all. It builds now.

Separately, there was no `.dockerignore`, so `docker build .` copied the working tree into the context and a local `build/` directory made the image build fail with `Directory '/build/keep-esp32/build' doesn't seem to be a CMake build directory`. A hermetic build must not depend on host state; that is now excluded.

## Still not reproducible, and deliberately out of scope

Fixing the pins does **not** make `verify-release` match. The release artifacts are built by `espressif/esp-idf-ci-action@v1` in `release.yml`, while `Dockerfile.reproducible` builds in a digest-pinned image with `SOURCE_DATE_EPOCH=0`, `IDF_CCACHE_ENABLE=0` and its own `-fmacro-prefix-map`. Two different harnesses cannot produce identical bytes. Making the release publish the reproducible artifacts is a release-process change and is tracked separately (`hq-cz1`), because it should be reviewed on its own terms rather than smuggled into a dependency bump.

## Not in this PR

**libnostr-c v0.1.5 → v0.2.0.** Also a security release (integer overflow in the tag arena allocator, missing `secure_wipe` on secp256k1 keypair and NIP-44 key error paths, constant-time session-id comparison). Held back because it is a minor-version jump on the library that performs Nostr signing and NIP-44, so an API break is plausible and it deserves its own build and hardware verification. Mixing it with a libwally bump would make a bisect ambiguous if the device misbehaves.

## Test plan
- [x] `idf.py build` against libwally 1.5.6: BUILD SUCCEEDED
- [x] **Clean-vs-clean warning comparison** against the pre-change commit: byte-identical warning sets, so the bump introduces none. (An incremental baseline gives a misleading diff here; both sides were built from scratch.)
- [x] Native suite green (`just test`, exit 0), including `test_psbt_fraud_integration` which links real libwally
- [x] `just docker-build` succeeds — it did not before this change — producing `keep.bin` and `keep-merged.bin`
- [x] `scripts/check-rng-hygiene.sh` clean
- [ ] **Hardware flash and `get_status` check — not done.** The board was disconnected partway through; `/dev/ttyACM0` is gone. The reproducible-build output is ready to flash and should be verified on a device before this is trusted for a release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved reproducible builds by pinning external build dependencies to specific immutable revisions.
  - Updated the bundled `libwally-core` version used for release builds.
  - Reduced Docker build contexts by excluding local outputs, generated files, metadata, and legacy build artifacts.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->