### PR TITLE
Catch dependency pin drift that dependabot cannot see

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+# Matches the weekly/grouped shape used by keep and keep-android.
+#
+# Note what this can and cannot see. Dependabot understands `uses:` in workflows
+# and `FROM` in Dockerfiles. It has NO ecosystem for the four upstream C
+# dependencies this firmware actually builds against: those are `git clone` in a
+# RUN step in Dockerfile.reproducible plus `ref:` values passed to
+# actions/checkout. They were invisible to dependabot while libwally-core sat
+# five security releases behind. scripts/check-dependency-pins.sh covers that
+# gap; this file covers the rest.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all:
+        patterns: ["*"]
+    open-pull-requests-limit: 5
+
+  # The ESP-IDF base image in Dockerfile.reproducible. It is digest-pinned, which
+  # is correct for reproducibility and also means it will never float on its own.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependency-pins.yml
+++ b/.github/workflows/dependency-pins.yml
@@ -1,0 +1,45 @@
+name: Dependency Pins
+
+# Two jobs with different strictness, on purpose.
+#
+# On a PR the check is advisory about freshness: an upstream release landing
+# mid-review should not turn an unrelated change red. It still HARD-FAILS if the
+# pins disagree between Dockerfile.reproducible and the workflows, or if any of
+# them is a branch or tag rather than a commit, because those are defects in the
+# diff under review.
+#
+# The scheduled run uses --strict, so upstream drift surfaces as its own failure
+# on a known day rather than never. See scripts/check-dependency-pins.sh for why
+# dependabot does not cover these dependencies.
+
+permissions:
+  contents: read
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Mondays, a few hours after the dependabot window so the two do not collide.
+    - cron: "0 9 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  agreement:
+    name: Pins agree and are commits
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-dependency-pins.sh
+
+  drift:
+    name: Pins are current with upstream
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./scripts/check-dependency-pins.sh --strict

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Fail if the upstream dependency pins have drifted, or disagree between the
+# three places that declare them.
+#
+# Why this exists and dependabot does not cover it: every dependency of this
+# firmware is a `git clone` in Dockerfile.reproducible plus a `ref:` passed to
+# actions/checkout in the workflows. Dependabot has no ecosystem for either --
+# it understands `uses:`, `FROM`, and package manifests. So the pins here are
+# invisible to it.
+#
+# That is not hypothetical. Before this check existed:
+#   - libwally-core sat on release_1.5.1 while 1.5.2 through 1.5.6 shipped, every
+#     one of them labelled "Users are advised to update as soon as possible",
+#     including PSBT parse hardening and a BIP-341 signing fix on the path that
+#     handles attacker-supplied PSBTs.
+#   - secp256k1-frost and noscrypt were checked out BY BRANCH in CI, so they were
+#     not pinned at all: a push to someone else's fork silently changed what this
+#     repo built and released.
+#   - Dockerfile.reproducible pinned secp256k1-frost to a commit that was not even
+#     on the branch CI used, so the reproducible build failed outright.
+# Nothing failed, nothing reported, CI was green throughout. That is the same
+# shape as the RNG defect scripts/check-rng-hygiene.sh exists to catch.
+#
+# Two rules:
+#   1. AGREEMENT  - Dockerfile.reproducible and both workflows must name the
+#      identical commit for every dependency, and it must be a 40-hex commit, not
+#      a branch or tag. Runs offline; always enforced.
+#   2. FRESHNESS  - each pin is compared against upstream. Requires network; skipped
+#      with a clear message when unavailable so the agreement rule still runs.
+#
+# Freshness is a WARNING by default and only fails under --strict, because an
+# upstream release landing should not turn an unrelated PR red. The scheduled
+# workflow runs --strict so drift surfaces as its own failure.
+#
+# Run from anywhere. Exits non-zero on a violation.
+
+set -uo pipefail
+cd "$(dirname "$0")/.." || exit 1
+
+STRICT=0
+[ "${1:-}" = "--strict" ] && STRICT=1
+
+status=0
+fail() { printf '\n\033[31mFAIL\033[0m %s\n' "$1"; status=1; }
+warn() { printf '\n\033[33mWARN\033[0m %s\n' "$1"; }
+
+DOCKERFILE='Dockerfile.reproducible'
+WORKFLOWS='.github/workflows/ci.yml .github/workflows/release.yml'
+
+for f in $DOCKERFILE $WORKFLOWS; do
+  [ -f "$f" ] || { fail "$f not found; this guard cannot run (was it moved?)"; exit 1; }
+done
+
+# repo -> commit, as declared in the Dockerfile's clone loop.
+docker_pins=$(grep -oE '"(privkeyio|ElementsProject)/[A-Za-z0-9._-]+ [a-f0-9]{40}"' "$DOCKERFILE" \
+  | tr -d '"' | sort -u)
+
+if [ -z "$docker_pins" ]; then
+  fail "no commit pins found in $DOCKERFILE; the guard would pass vacuously"
+  exit 1
+fi
+
+# ------------------------------------------------------- 1. agreement ------
+while read -r repo pin; do
+  [ -n "$repo" ] || continue
+  for wf in $WORKFLOWS; do
+    # the `ref:` line following `repository: <repo>`, skipping comment lines
+    wf_ref=$(awk -v r="repository: $repo\$" '
+      $0 ~ r { found = 1; next }
+      found && /^[[:space:]]*#/ { next }
+      found && /^[[:space:]]*ref:/ { sub(/^[[:space:]]*ref:[[:space:]]*/, ""); sub(/[[:space:]]*#.*$/, ""); print; exit }
+      found && NF == 0 { exit }
+    ' "$wf")
+    if [ -z "$wf_ref" ]; then
+      fail "$wf does not check out $repo, but $DOCKERFILE pins it. The reproducible build and CI would build different sources."
+      continue
+    fi
+    if ! printf '%s' "$wf_ref" | grep -qE '^[a-f0-9]{40}$'; then
+      fail "$wf pins $repo to '$wf_ref', which is a branch or tag, not a commit."
+      echo "  → a branch ref is not a pin: whoever can push to it changes what this repo builds"
+      echo "    and releases, with no diff here. Tags can be force-moved. Use the commit SHA."
+      continue
+    fi
+    if [ "$wf_ref" != "$pin" ]; then
+      fail "$repo disagrees between $DOCKERFILE and $wf:"
+      echo "    $DOCKERFILE: $pin"
+      echo "    $wf:        $wf_ref"
+      echo "  → the reproducible build and the released artifact would be built from different source."
+    fi
+  done
+done <<EOF
+$docker_pins
+EOF
+
+# ------------------------------------------------------- 2. freshness ------
+if ! git ls-remote --exit-code https://github.com/privkeyio/keep-esp32.git HEAD >/dev/null 2>&1; then
+  echo
+  echo "NOTE: no network access to github.com; skipping the freshness check."
+  echo "      The agreement rule above still ran."
+else
+  while read -r repo pin; do
+    [ -n "$repo" ] || continue
+    url="https://github.com/$repo.git"
+    # Newest semver-ish tag, if the project tags releases at all.
+    latest_tag=$(git ls-remote --tags --refs "$url" 2>/dev/null \
+      | awk -F'refs/tags/' '{print $2}' | grep -E '^(v|release_)?[0-9]+\.[0-9]+' | sort -V | tail -1)
+    if [ -n "$latest_tag" ]; then
+      tag_commit=$(git ls-remote "$url" "refs/tags/$latest_tag^{}" 2>/dev/null | cut -f1)
+      [ -z "$tag_commit" ] && tag_commit=$(git ls-remote "$url" "refs/tags/$latest_tag" 2>/dev/null | cut -f1)
+      if [ -n "$tag_commit" ] && [ "$tag_commit" != "$pin" ]; then
+        msg="$repo is pinned to ${pin:0:8} but upstream's newest release is $latest_tag (${tag_commit:0:8})"
+        if [ "$STRICT" -eq 1 ]; then fail "$msg"; else warn "$msg"; fi
+        echo "  → review the changelog before bumping; these are consumed by a signer's"
+        echo "    untrusted-input paths, so a 'patch' release can still be security-relevant."
+      fi
+    else
+      # Fork with no releases: the useful signal is the tip of the branch it was cut from.
+      for br in esp-idf-support main master; do
+        tip=$(git ls-remote "$url" "refs/heads/$br" 2>/dev/null | cut -f1)
+        [ -n "$tip" ] || continue
+        if [ "$tip" != "$pin" ]; then
+          msg="$repo is pinned to ${pin:0:8} but $br is at ${tip:0:8}"
+          if [ "$STRICT" -eq 1 ]; then fail "$msg"; else warn "$msg"; fi
+        fi
+        break
+      done
+    fi
+  done <<EOF
+$docker_pins
+EOF
+fi
+
+if [ "$status" -eq 0 ]; then
+  echo "Dependency pins: OK (all commit-pinned and identical across $DOCKERFILE and the workflows)"
+fi
+exit "$status"


### PR DESCRIPTION
## Summary
- Adds `scripts/check-dependency-pins.sh` and a `Dependency Pins` workflow that catch upstream pin drift and pin disagreement.
- Adds `.github/dependabot.yml` for the ecosystems dependabot *can* see, matching the weekly/grouped shape keep and keep-android already use.

## Why a custom check, when dependabot exists

Dependabot understands `uses:` in workflows, `FROM` in Dockerfiles, and package manifests. **Every upstream C dependency of this firmware is none of those**: they are `git clone` in a `RUN` step in `Dockerfile.reproducible`, plus `ref:` values passed to `actions/checkout`. Dependabot has no ecosystem for either, so those four pins were invisible to it and would have stayed invisible.

That is not a hypothetical gap. Before #146, and with CI green the whole time:

- `libwally-core` sat on `release_1.5.1` while 1.5.2 through 1.5.6 shipped, every one labelled *"Users are advised to update as soon as possible"*, including PSBT parse hardening and a BIP-341 signing fix on the path that handles attacker-supplied PSBTs.
- `secp256k1-frost` and `noscrypt` were checked out **by branch**, so they were not pinned at all: a push to a fork silently changed what this repo built and released.
- `Dockerfile.reproducible` pinned `secp256k1-frost` to a commit that was not on the branch CI used, so the reproducible build failed outright.

Same shape as the RNG defect `check-rng-hygiene.sh` exists to catch: silent, green, and only visible if something mechanical looks for it.

**Evidence the check works:** run against `main` as it stood *before* #146, it independently reported all four problems — the branch refs, the stale libwally, the stale libnostr-c, and the off-branch secp256k1 pin. It was written from the Dockerfile, not from my notes, and it rediscovered the same findings.

## Two rules, two strictness levels

**Agreement** (always enforced, offline): `Dockerfile.reproducible` and both workflows must name the *identical 40-hex commit* for every dependency. A branch or tag is rejected outright, with the reason stated at the failure site. This is what stops the reproducible build and the released artifact being built from different source, and what stops a dependency floating.

**Freshness** (network): each pin is compared against upstream's newest release tag, or the branch tip for forks that do not tag. This is a **warning on PRs and a failure only on the weekly schedule**, deliberately: an upstream release landing mid-review should not turn an unrelated PR red, but drift should still surface on a known day rather than never.

If the network is unavailable the freshness half is skipped with an explicit message, and the agreement half still runs — it never silently degrades into a pass.

## Known state on merge

The freshness check currently warns that `libnostr-c` is behind `v0.2.0`. That is correct and deliberate: v0.2.0 is a security release (integer overflow in the tag arena allocator, missing `secure_wipe` on secp256k1 keypair and NIP-44 key error paths, constant-time session-id comparison), but it is a minor-version jump on the library that performs Nostr signing and NIP-44, so it is being handled as its own change with its own hardware verification rather than folded in here. The weekly `--strict` run will fail on it until that lands, which is the intended behaviour: a deliberate deferral should stay visible, not be silenced.

## Test plan
- [x] `bash -n` clean; both YAML files parse
- [x] Verified against pre-#146 `main`: reports the branch refs as failures and all three stale pins as warnings
- [x] Verified against post-#146 `main`: agreement rule passes, only the deliberate `libnostr-c` warning remains, exit 0
- [x] `scripts/check-rng-hygiene.sh` still clean
- [ ] The scheduled `--strict` job has not run yet; it fires Mondays or on `workflow_dispatch`
