### PR TITLE
Pin the IDF managed components and keep the job token out of PR-controlled trees

### DIFF
--- a/.github/workflows/dependency-pins.yml
+++ b/.github/workflows/dependency-pins.yml
@@ -33,6 +33,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job checks out a PR branch and then EXECUTES a script from it.
+          # actions/checkout persists GITHUB_TOKEN into .git/config by default,
+          # which would leave it readable by PR-authored code. Nothing here needs
+          # git credentials.
+          persist-credentials: false
       - run: ./scripts/check-dependency-pins.sh
 
   drift:
@@ -42,4 +48,10 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job checks out a PR branch and then EXECUTES a script from it.
+          # actions/checkout persists GITHUB_TOKEN into .git/config by default,
+          # which would leave it readable by PR-authored code. Nothing here needs
+          # git credentials.
+          persist-credentials: false
       - run: ./scripts/check-dependency-pins.sh --strict

--- a/.github/workflows/rng-hygiene.yml
+++ b/.github/workflows/rng-hygiene.yml
@@ -13,6 +13,9 @@ name: RNG Hygiene
 # path-filtered job can never be a required status check -- PRs touching none of
 # the filtered globs report nothing and block forever.
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]
@@ -25,6 +28,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # This job checks out a PR branch and then EXECUTES a script from it.
+          # actions/checkout persists GITHUB_TOKEN into .git/config by default,
+          # which would leave it readable by PR-authored code. Nothing here needs
+          # git credentials.
+          persist-credentials: false
 
       - name: Check for silent RNG fallbacks
         run: ./scripts/check-rng-hygiene.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
 build/
 managed_components/
-dependencies.lock
+# dependencies.lock is TRACKED on purpose. main/idf_component.yml constrains the
+# ESP-IDF managed components by caret range (^1.7.18, ^3.0.2, ...), so without the
+# lockfile a clean build re-resolves them from the registry and two builds on
+# different days can differ. Dockerfile.reproducible pins the four git
+# dependencies by commit; this pins the rest. Regenerate with `idf.py reconfigure`
+# and commit the result when a component is intentionally bumped.
 sdkconfig
 sdkconfig.old
 *.pyc

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -1,0 +1,170 @@
+dependencies:
+  espressif/cjson:
+    component_hash: 9372811fb197926f522c467627cf4a8e72b681e0366e17879631da801103aef3
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.7.19
+  espressif/cmake_utilities:
+    component_hash: 351350613ceafba240b761b4ea991e0f231ac7a9f59a9ee901f751bddc0bb18f
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 0.5.3
+  espressif/esp32-camera:
+    component_hash: bc9c8a6b51df777a014fa295825b3de5069bc0300c317acff20c97cf4a10ac7d
+    dependencies:
+    - name: espressif/esp_jpeg
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^1.3.1
+    - name: idf
+      require: private
+      version: '>=5.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 2.1.7
+  espressif/esp_codec_dev:
+    component_hash: df70f10af8d7b922add7b9d07372c9c97ab356e58d72b7a892050227c2d44348
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.5.11
+  espressif/esp_jpeg:
+    component_hash: defb83669293cbf86d0fa86b475ba5517aceed04ed70db435388c151ab37b5d7
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.3.1
+  espressif/esp_lcd_ili9341:
+    component_hash: 0baab584e0e490511d6bdbae6aa045130424d732ecdaad6cd1d3bd3c0abe2c30
+    dependencies:
+    - name: espressif/cmake_utilities
+      registry_url: https://components.espressif.com
+      require: private
+      version: 0.*
+    - name: idf
+      require: private
+      version: '>=4.4'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 2.0.2
+  espressif/esp_lcd_touch:
+    component_hash: 3f85a7d95af876f1a6ecca8eb90a81614890d0f03a038390804e5a77e2caf862
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.4.2'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.2.1
+  espressif/esp_lcd_touch_ft5x06:
+    component_hash: 8ae101b4a321b6327d98751b049e3c7fff2718ad04d676259369ff85d4edbcdf
+    dependencies:
+    - name: espressif/esp_lcd_touch
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^1.2.0
+    - name: idf
+      require: private
+      version: '>=5.2'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 1.1.0~1
+  espressif/esp_lvgl_port:
+    component_hash: fb6c1fdfe70d4ca39a035d63ca394a35f17ec84ce16ff98ecb13a54155d75da4
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.2'
+    - name: lvgl/lvgl
+      registry_url: https://components.espressif.com
+      require: public
+      version: '>=8,<10'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 2.8.0~1
+  espressif/esp_websocket_client:
+    component_hash: c5a067a9fddea370c478017e66fac302f4b79c3d4027e9bdd42a019786cceb92
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=5.0'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    version: 1.6.1
+  espressif/m5stack_core_s3:
+    component_hash: 2b578980fc81304857504b8a92e1693e8529966f097fd626b251d0b052bf6a48
+    dependencies:
+    - name: espressif/esp32-camera
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^2.0.11
+    - name: espressif/esp_codec_dev
+      registry_url: https://components.espressif.com
+      require: public
+      version: ~1.5
+    - name: espressif/esp_lcd_ili9341
+      registry_url: https://components.espressif.com
+      require: private
+      version: ^2.0.1
+    - name: espressif/esp_lcd_touch_ft5x06
+      registry_url: https://components.espressif.com
+      require: private
+      version: ^1
+    - name: espressif/esp_lvgl_port
+      registry_url: https://components.espressif.com
+      require: public
+      version: ^2
+    - name: idf
+      require: private
+      version: '>=5.4'
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32s3
+    version: 3.0.2
+  idf:
+    source:
+      type: idf
+    version: 5.4.1
+  lvgl/lvgl:
+    component_hash: 184e532558c1c45fefed631f3e235423d22582aafb4630f3e8885c35281a49ae
+    dependencies: []
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 9.5.0
+direct_dependencies:
+- espressif/cjson
+- espressif/esp_lcd_touch
+- espressif/esp_lvgl_port
+- espressif/esp_websocket_client
+- espressif/m5stack_core_s3
+- idf
+manifest_hash: 1dbe2815e16eea139bd87c5ee65bf0184834b31f0ae17336273ffae551d06766
+target: esp32s3
+version: 2.0.0

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -26,7 +26,7 @@ $ keep-esp32-rpc get_status
 ```
 
 - `rng_entropy_source` **absent** — pre-fix firmware. The RNG ran without a continuous entropy source.
-- `rng_entropy_source: false` — fixed firmware, but the SAR ADC entropy path did not come up. Do not provision; the boot log carries `Entropy source did not come up`.
+- `rng_entropy_source: false` — fixed firmware, but the SAR ADC entropy path did not come up. Do not provision. The boot log carries both `Entropy source did not come up; RNG output is pseudo-random only` (from `hw_entropy_init`) and `Hardware entropy source not running; RNG output is pseudo-random only` (from `rng_init`); grep for `pseudo-random`, which appears in each.
 - `rng_entropy_source: true` — the entropy source is running.
 
 Note that `rng_healthy`, `self_test_ok` and `rng_failed_checks` stay green in all three cases. They are statistical checks, and a seeded PRNG passes statistical checks; that is the whole reason `rng_entropy_source` exists. This was confirmed on hardware in both directions.


### PR DESCRIPTION
## Summary
Three fixes, all from CodeRabbit review comments on already-merged PRs that I had not read. Two are supply-chain issues in tooling I added myself.

## 1. The reproducible build did not pin the ESP-IDF managed components

`main/idf_component.yml` constrains them by **caret range** — `espressif/cjson: "^1.7.18"`, `esp_websocket_client: "^1.2.3"`, `m5stack_core_s3: "^3.0.2"` — and `dependencies.lock`, which carries a `component_hash` per component plus a `manifest_hash`, was explicitly gitignored at `.gitignore:3`.

So #146 pinned the four git dependencies by commit and then left everything else to be re-resolved from the registry at build time. A `^1.7.18` constraint happily accepts 1.7.20 or 1.8.0, so two builds on different days could differ.

Before #146 there was no `.dockerignore`, so the host's resolved `managed_components/` was copied into the build context and accidentally pinned this. Making the build properly hermetic removed that accident and exposed that the components had never been pinned deliberately. The lockfile is now tracked, with the reasoning recorded in `.gitignore` next to where it used to be discarded.

**Measured, and stated precisely:** with and without the tracked lockfile the output is byte-identical today (`e4988d03…`), because the caret ranges currently resolve to exactly what the lock pins. This change is **behaviour-preserving now and preventive later** — it stops the drift, it does not fix a present mismatch. Two independent Docker builds of identical source producing identical hashes is also a useful data point on its own: the reproducible path is deterministic run to run.

## 2. The guard workflows handed a token to code the PR author controls

`rng-hygiene` and `dependency-pins` both check out a PR branch and then **execute a shell script from it**. `actions/checkout` persists `GITHUB_TOKEN` into `.git/config` by default, so `check-rng-hygiene.sh` — a file any PR author can edit — could read it. `permissions: contents: read` bounds the damage; `persist-credentials: false` removes the token from the tree entirely. Neither job needs git credentials.

The same fix is going to keep and keep-node, which have the same shape.

## 3. Documented boot-log text was incomplete

`docs/SECURITY.md` told operators to look for `Entropy source did not come up`, which `hw_entropy_init` emits, while `rng_init` separately emits `Hardware entropy source not running; RNG output is pseudo-random only`. Both appear on a degraded boot — confirmed on hardware during the negative-control run. The doc now names both and points at the substring common to them.

## On process

These came from CodeRabbit comments on #144, #145 and #146 that I merged past because I read the checks summary rather than the review. Of the fifteen comments across all PRs, most had already been fixed by later commits in the same branches, but these had not — and the two supply-chain ones are in tooling I introduced. Reading inline review comments is now part of the pre-merge loop, not the post-merge one.

## Test plan
- [x] `just docker-build` succeeds with the tracked lockfile; output byte-identical to the pre-lockfile build of the same source
- [x] `scripts/check-rng-hygiene.sh` and `scripts/check-dependency-pins.sh` both clean
- [x] Both workflow files parse as YAML
- [ ] The `persist-credentials` change cannot be verified locally; it takes effect on the next CI run of these workflows
