### PR TITLE
Pin libnostr-c to the branch carrying its security fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/libnostr-c
-          ref: 724868d508d5fa02f11d6e9549a225c60a4132e1 # v0.1.5
+          ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
           path: libnostr-c
 
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: privkeyio/libnostr-c
-          ref: 724868d508d5fa02f11d6e9549a225c60a4132e1 # v0.1.5
+          ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
           path: libnostr-c
 
       - uses: actions/checkout@v4

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -15,7 +15,7 @@ COPY . keep-esp32/
 
 RUN for repo in \
         "privkeyio/secp256k1-frost 746dbbea5c34dde963c9bd55bc7474b2d50fa597" \
-        "privkeyio/libnostr-c 724868d508d5fa02f11d6e9549a225c60a4132e1" \
+        "privkeyio/libnostr-c 205aaf5ae849d6408dab41ca5be2abfc24801ad9" \
         "privkeyio/noscrypt 45fcbef32f958145d6797f384a225c0d43616886" \
         "ElementsProject/libwally-core 0c41f38fb1c201786e9c3ac9eae4f5f80c051399"; do \
         set -- $repo; \


### PR DESCRIPTION
## Summary

Moves the `libnostr-c` pin in `Dockerfile.reproducible` from `724868d` (v0.1.5) to `205aaf5`, 19 commits ahead. The gap includes v0.2.0, "Harden against JSON injection, memory safety, and crypto wiping issues", and the ESP32 RNG fix where `esp_fill_random` returned success unconditionally so a failure could not propagate, and NIP-44 bypassed the checked RNG entirely.

Pinned to `205aaf5` rather than the `v0.2.0` tag because the tag predates that RNG fix.

## What this does not do

It does not change what runs on the device, and the PR should not be read as delivering those fixes to hardware.

Built the firmware at both pins and compared. The images differ in exactly 65 bytes, in two ranges:

| range | field |
|---|---|
| `0xB0`-`0xCF` (32 bytes) | `app_elf_sha256` in `esp_app_desc_t` |
| last 33 bytes | image validation hash plus checksum |

`esptool image_info` confirms it: `ELF file SHA256` and `Validation hash` differ, while `Project name`, `App version` and `Compile time` are identical. Every executable byte is the same.

The reason is that almost none of libnostr-c reaches the firmware. `liblibnostr-c.a` compiles 201 `nostr_*` symbols and the linker keeps two, `nostr_hex_encode` and `nostr_hex_decode`. `nostr_random_bytes`, `nostr_key_generate` and `nostr_init` are compiled and then garbage-collected, so the RNG fix is not reachable code here. Same shape as the noscrypt situation in keep-esp32-hq-7ol, where `libnoscrypt.a` builds at 261 KB and contributes zero symbols.

So this is supply-chain hygiene: the pinned source should be the version with the fixes, and it will matter the moment any of that code becomes reachable. It is not a behavior change and should not be described as one in release notes.

## Test plan

- [x] `205aaf5` verified to exist and be on `privkeyio/libnostr-c` `origin/main`
- [x] Firmware builds clean at the new pin, `keep.bin` 0xe4290, 70% partition free
- [x] Symbol table and per-symbol sizes identical between the two builds
- [x] **Determinism control**: rebuilding the same pin after `touch main/main.c` reproduces byte-identical output, so the old-versus-new difference is a real change and not embedded build metadata
- [x] Differing bytes localized to the two hash fields above
- [x] Local symlinked `libnostr-c` and `noscrypt` checkouts confirmed to match their pinned commits before building, so the build tested the pinned code

`dependencies.lock` was left untouched. Both builds rewrote it (`esp_lcd_touch_ft5x06` 1.1.0~1 to 1.1.0~2, a transitive component under a caret range), which is tracked separately as keep-esp32-hq-rr5: nothing in CI fails when a build re-resolves that lock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency revision used for reproducible Docker builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->