### PR TITLE
Fail the build when it re-resolves the component lock

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,11 +41,40 @@ jobs:
           ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
           path: libwally-core
 
+      - name: Record the component lock hash before building
+        id: lockhash
+        working-directory: keep-esp32
+        run: echo "sha=$(sha256sum dependencies.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+
       - uses: espressif/esp-idf-ci-action@v1
         with:
           esp_idf_version: v5.4.1
           target: esp32s3
           path: keep-esp32
+
+      # dependencies.lock is tracked so the managed-component set is pinned, but
+      # main/idf_component.yml uses caret ranges. The component manager happily
+      # re-resolves within those ranges and rewrites the lock mid-build, which
+      # would otherwise ship a different transitive set than the one committed
+      # and leave no signal that it happened.
+      #
+      # Compared by hash rather than `git diff`: the IDF action builds in a
+      # container as root, so the checkout can end up owned by another uid and
+      # git would abort with "dubious ownership" instead of comparing.
+      - name: Fail if the build re-resolved the component lock
+        working-directory: keep-esp32
+        env:
+          BEFORE: ${{ steps.lockhash.outputs.sha }}
+        run: |
+          after=$(sha256sum dependencies.lock | cut -d' ' -f1)
+          if [ "$after" != "$BEFORE" ]; then
+            echo "::error::dependencies.lock was rewritten by the build; the committed component set is not what was built." >&2
+            echo "  before: $BEFORE" >&2
+            echo "  after:  $after" >&2
+            echo "Commit the updated lock deliberately, or tighten the ranges in main/idf_component.yml." >&2
+            exit 1
+          fi
+          echo "dependencies.lock unchanged ($after): built the committed component set."
 
   native-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Record the component lock hash before building
         id: lockhash
         working-directory: keep-esp32
-        run: echo "sha=$(sha256sum dependencies.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+        run: |
+          cp dependencies.lock "$RUNNER_TEMP/dependencies.lock.before"
+          echo "sha=$(sha256sum dependencies.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
       - uses: espressif/esp-idf-ci-action@v1
         with:
@@ -71,6 +73,7 @@ jobs:
             echo "::error::dependencies.lock was rewritten by the build; the committed component set is not what was built." >&2
             echo "  before: $BEFORE" >&2
             echo "  after:  $after" >&2
+            diff -u "$RUNNER_TEMP/dependencies.lock.before" dependencies.lock >&2 || true
             echo "Commit the updated lock deliberately, or tighten the ranges in main/idf_component.yml." >&2
             exit 1
           fi

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -78,7 +78,7 @@ dependencies:
       type: service
     version: 1.2.1
   espressif/esp_lcd_touch_ft5x06:
-    component_hash: 8ae101b4a321b6327d98751b049e3c7fff2718ad04d676259369ff85d4edbcdf
+    component_hash: cb8247f88952ab71236110b92b15f1a4360453f9faaf516234908de27cece8ee
     dependencies:
     - name: espressif/esp_lcd_touch
       registry_url: https://components.espressif.com
@@ -90,7 +90,7 @@ dependencies:
     source:
       registry_url: https://components.espressif.com
       type: service
-    version: 1.1.0~1
+    version: 1.1.0~2
   espressif/esp_lvgl_port:
     component_hash: fb6c1fdfe70d4ca39a035d63ca394a35f17ec84ce16ff98ecb13a54155d75da4
     dependencies:
@@ -165,6 +165,6 @@ direct_dependencies:
 - espressif/esp_websocket_client
 - espressif/m5stack_core_s3
 - idf
-manifest_hash: 1dbe2815e16eea139bd87c5ee65bf0184834b31f0ae17336273ffae551d06766
+manifest_hash: f91c307533d08a2c00806e576fc7f20d242dab14b972db21047300e6cb04e49d
 target: esp32s3
 version: 2.0.0


### PR DESCRIPTION
## Summary

`dependencies.lock` is tracked so the managed-component set is pinned, but nothing verified that a build actually used it. Now CI records the lock's hash before the ESP-IDF build and fails if it changed afterwards.

## Why

Running `idf.py build` locally on `cdc1ada` silently rewrote the tracked lock:

```
espressif/esp_lcd_touch_ft5x06: 1.1.0~1 -> 1.1.0~2
component_hash: 8ae101b4... -> cb8247f8...
manifest_hash:  1dbe2815... -> f91c3075...
```

`main/idf_component.yml` pins direct dependencies with caret ranges (`^1.7.18`, `^1.2.3`, `^3.0.2`, `^1.2.1`, `^2.7.0`). `esp_lcd_touch_ft5x06` is not even listed there; it arrives transitively through `m5stack_core_s3` / `esp_lcd_touch`. The lockfile is the only thing pinning it to an exact version and hash.

Before this change, `grep` found no reference to `dependencies.lock` anywhere in `.github/workflows/` or `scripts/`. A build could re-resolve within the ranges, use a different transitive set than the committed one, go green, and leave no signal. The four direct source dependencies are carefully commit-pinned, with a comment in `ci.yml` explaining that a branch ref lets anyone with push access change what CI builds; the managed components had no equivalent enforcement.

This does not make updates hard. It makes them explicit: the lock still updates, it just has to be committed and reviewed, the same way `Cargo.lock` is handled in keep.

## Implementation note

Compared by hash rather than `git diff --exit-code`. The IDF action builds inside a container as root, so the checkout can end up owned by a different uid and git would abort with "dubious ownership" rather than compare, turning a guard into a spurious failure with a misleading message. `sha256sum` has no such dependency on repository ownership.

Left as a plain step rather than `if: always()`, so a failed build reports its own error instead of stacking a lock mismatch on top of it.

## Test plan

Simulated both steps exactly as CI runs them:

- [x] Lock untouched: passes, reports `unchanged (fa9be08d...)`
- [x] **Negative control**, lock rewritten mid-build (`1.1.0~1` to `1.1.0~2`, the real drift observed): fires, exit 1, prints both hashes
- [x] Restored: passes again
- [x] `ci.yml` parses as YAML, step order is record-hash then build then compare

## Follow-up not included here

`main/idf_component.yml` uses caret ranges, so the range is the real policy and the lock is what makes it reproducible. Whether those should be exact pins is a separate decision, tracked in keep-esp32-hq-rr5, and complementary to this rather than an alternative.