### PR TITLE
Pin GitHub Actions by commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           # Pinned by commit, not branch: a branch ref means anyone with push
@@ -23,19 +23,19 @@ jobs:
           ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/libnostr-c
           ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
           path: libnostr-c
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/noscrypt
           ref: 45fcbef32f958145d6797f384a225c0d43616886
           path: noscrypt
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ElementsProject/libwally-core
           ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
@@ -48,7 +48,7 @@ jobs:
           cp dependencies.lock "$RUNNER_TEMP/dependencies.lock.before"
           echo "sha=$(sha256sum dependencies.lock | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
 
-      - uses: espressif/esp-idf-ci-action@v1
+      - uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1.2.0
         with:
           esp_idf_version: v5.4.1
           target: esp32s3
@@ -83,11 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           # Pinned by commit, not branch: a branch ref means anyone with push
@@ -95,7 +95,7 @@ jobs:
           ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ElementsProject/libwally-core
           ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
@@ -136,7 +136,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft != true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install Doxygen
         run: sudo apt-get update && sudo apt-get install -y doxygen
@@ -145,7 +145,7 @@ jobs:
         run: doxygen Doxyfile
 
       - name: Upload docs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: docs
           path: docs/html

--- a/.github/workflows/dependency-pins.yml
+++ b/.github/workflows/dependency-pins.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # This job checks out a PR branch and then EXECUTES a script from it.
           # actions/checkout persists GITHUB_TOKEN into .git/config by default,
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # This job checks out a PR branch and then EXECUTES a script from it.
           # actions/checkout persists GITHUB_TOKEN into .git/config by default,

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,9 +8,9 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ElementsProject/libwally-core
           ref: release_1.5.1
@@ -51,7 +51,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: fuzz-crashes
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           # Pinned by commit, not branch: a branch ref means anyone with push
@@ -27,26 +27,26 @@ jobs:
           ref: 746dbbea5c34dde963c9bd55bc7474b2d50fa597
           path: secp256k1-frost
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/libnostr-c
           ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
           path: libnostr-c
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/noscrypt
           ref: 45fcbef32f958145d6797f384a225c0d43616886
           path: noscrypt
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: ElementsProject/libwally-core
           ref: 0c41f38fb1c201786e9c3ac9eae4f5f80c051399 # release_1.5.6
           path: libwally-core
 
       - name: Build ESP32-S3 firmware
-        uses: espressif/esp-idf-ci-action@v1
+        uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1.2.0
         with:
           esp_idf_version: v5.4.1
           target: esp32s3
@@ -78,7 +78,7 @@ jobs:
           tar -czvf ../keep-esp32-firmware-${{ github.ref_name }}.tar.gz *
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: keep-esp32-firmware
           path: keep-esp32-firmware-*.tar.gz
@@ -91,7 +91,7 @@ jobs:
           cp release/keep-merged.bin pages/
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: pages
 
@@ -104,22 +104,22 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
 
   release:
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: artifacts
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: artifacts/**/*
           generate_release_notes: true

--- a/.github/workflows/rng-hygiene.yml
+++ b/.github/workflows/rng-hygiene.yml
@@ -27,7 +27,7 @@ jobs:
     name: No predictable-RNG fallbacks
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # This job checks out a PR branch and then EXECUTES a script from it.
           # actions/checkout persists GITHUB_TOKEN into .git/config by default,

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install clang-format
         run: sudo apt-get update && sudo apt-get install -y clang-format
@@ -21,11 +21,11 @@ jobs:
   cppcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           ref: esp-idf-support
@@ -59,11 +59,11 @@ jobs:
   clang-tidy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           ref: esp-idf-support
@@ -107,11 +107,11 @@ jobs:
   scan-build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           path: keep-esp32
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           repository: privkeyio/secp256k1-frost
           ref: esp-idf-support


### PR DESCRIPTION
## Summary

Pins all 36 action references across the six workflows to commit SHAs. Every one was a mutable tag.

## Why

`ci.yml` already carries this comment above its dependency checkouts:

> Pinned by commit, not branch: a branch ref means anyone with push access silently changes what CI builds and what we release.

That reasoning applies at least as strongly to the actions themselves, and they were the exception. `espressif/esp-idf-ci-action@v1` compiles the firmware for a device that holds keys, and `softprops/action-gh-release@v2` uploads the release artifacts. A tag is a pointer its owner can move, so `@v1` is a standing grant to run whatever that repository publishes next, inside a job that builds and signs what users flash. The four upstream C dependencies are pinned to 40-hex commits and checked by `scripts/check-dependency-pins.sh`; the actions had no equivalent.

## What was pinned

| action | pinned to | version |
|---|---|---|
| `actions/checkout` (27 uses) | `11d5960` | v4.4.0 |
| `actions/upload-artifact` (3) | `ea165f8` | v4.6.2 |
| `espressif/esp-idf-ci-action` (2) | `9d38657` | v1.2.0 |
| `softprops/action-gh-release` | `3bb1273` | v2.6.2 |
| `actions/upload-pages-artifact` | `56afc60` | v3.0.1 |
| `actions/download-artifact` | `d3f86a1` | v4.3.0 |
| `actions/deploy-pages` | `d6db901` | v4.0.5 |

Each SHA is what its tag resolved to at the time of writing, so this is not a version change and no behavior should differ. Each keeps a trailing `# vX.Y.Z` comment so the version stays readable.

Dependabot is already configured for `github-actions` in this repository, weekly and grouped, so these pins get maintained rather than frozen. Pinning without that would trade a supply-chain risk for a staleness one.

## Test plan

- [x] All six workflow files parse as YAML after rewriting
- [x] Zero mutable refs remain: `grep` for `@v[0-9]`, `@main`, `@master` in `uses:` returns nothing
- [x] Every pinned ref is exactly 40 hex characters
- [x] Reference counts unchanged at 36 total, so nothing was dropped or duplicated by the rewrite
- [ ] CI green, which exercises checkout, the IDF build and artifact upload on the new pins

Workflow logic is untouched; only `uses:` lines changed.