### PR TITLE
Splice line continuations before scanning, and self-test the guard

### DIFF
--- a/.github/workflows/rng-hygiene.yml
+++ b/.github/workflows/rng-hygiene.yml
@@ -35,5 +35,11 @@ jobs:
           # git credentials.
           persist-credentials: false
 
+      # Assert the guard's rules before trusting them. A line continuation split
+      # an identifier past the scanner, which defeated the SAR ADC rule holding
+      # the v0.2.1 entropy invariant, and nothing would have noticed.
+      - name: Self-test the RNG hygiene guard
+        run: ./scripts/test-rng-hygiene.sh
+
       - name: Check for silent RNG fallbacks
         run: ./scripts/check-rng-hygiene.sh

--- a/scripts/check-rng-hygiene.sh
+++ b/scripts/check-rng-hygiene.sh
@@ -116,6 +116,20 @@ preprocess() {
 
       BEGIN { inblock = 0; instr = 0; skip = 0; blockopt = 0 }
       {
+        # Splice C line continuations before anything looks at the text. A
+        # backslash-newline inside an identifier is legal: translation phase 2
+        # removes it before tokenization, so the compiler sees
+        # adc_oneshot_new_unit() while a per-physical-line scanner sees
+        # "adc_oneshot\\" and "_new_unit();" and matches neither. That defeated
+        # rule 5, the one holding the SAR ADC invariant behind the v0.2.1
+        # entropy fix. startline keeps the finding pointing at the first
+        # physical line, which is where a reader has to go to fix it.
+        startline = FNR
+        while (sub(/\\[ \t]*$/, "", $0) > 0) {
+          if ((getline nextpart) <= 0) break
+          $0 = $0 nextpart
+        }
+
         code = trim(strip($0))
 
         # A comment block carrying the marker covers the next code line, however
@@ -137,7 +151,7 @@ preprocess() {
 
         if (index(cmt, optout) || blockopt) { blockopt = 0; cmt = ""; next }
         blockopt = 0; cmt = ""
-        printf "%s:%d:%s\n", fname, FNR, code
+        printf "%s:%d:%s\n", fname, startline, code
       }
     ' "$f") || rc=2
     [ -n "$out" ] && printf '%s\n' "$out"

--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Self-test for check-rng-hygiene.sh.
+#
+# This guard holds the invariant behind the v0.2.1 entropy fix: the SAR ADC
+# source stays enabled for the life of the device, raw HWRNG draws stay in one
+# file, and nothing takes the ADC back. A scanner that quietly stops scanning
+# reports a clean tree exactly like a clean tree does, so the rules are asserted
+# rather than trusted.
+#
+# Each reject case requires the guard to NAME the probe file. Without that, a
+# guard aborting for an unrelated reason would be credited as a detection and
+# every case below would pass while detecting nothing.
+#
+# Probes are staged into a throwaway GIT_INDEX_FILE, so the real index is never
+# touched. The file itself must exist on disk while the guard runs, because the
+# scanner reads bytes; it is removed on every path including the EXIT trap.
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || { echo "FAIL: cannot cd to the repo root"; exit 1; }
+GUARD=scripts/check-rng-hygiene.sh
+[ -x "$GUARD" ] || { echo "FAIL: $GUARD not found or not executable"; exit 1; }
+
+TMPD=$(mktemp -d)
+PROBE=""
+cleanup() { rm -rf "$TMPD"; [ -n "$PROBE" ] && rm -f "$PROBE"; }
+trap cleanup EXIT
+
+fails=0
+
+# run_probe <path> <content> <pass|fail> <description>
+run_probe() {
+    local name="$1" content="$2" expect="$3" desc="$4"
+
+    if [ -e "$name" ]; then
+        echo "  HARNESS BROKEN: $name exists; refusing to overwrite a real file"
+        fails=$((fails + 1)); return
+    fi
+    PROBE="$name"
+    printf '%s' "$content" > "$name"
+
+    rm -f "$TMPD/index"
+    GIT_INDEX_FILE="$TMPD/index" git read-tree HEAD 2>/dev/null
+    GIT_INDEX_FILE="$TMPD/index" git add -f "$name" 2>/dev/null
+
+    local staged
+    staged=$(GIT_INDEX_FILE="$TMPD/index" git ls-files | wc -l)
+    if [ "$staged" -lt 10 ]; then
+        echo "  HARNESS BROKEN: only $staged file(s) staged; the guard would scan almost nothing"
+        fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
+    fi
+
+    local rc=0 out
+    out=$(GIT_INDEX_FILE="$TMPD/index" "$GUARD" 2>&1) || rc=$?
+    rm -f "$name"; PROBE=""
+
+    if [ "$expect" = fail ]; then
+        if [ "$rc" -eq 0 ]; then
+            echo "  BYPASS: $desc"; fails=$((fails + 1))
+        elif ! printf '%s' "$out" | grep -qF "$name"; then
+            echo "  WRONG REASON: $desc (guard failed without naming $name)"; fails=$((fails + 1))
+        else
+            echo "  ok: $desc"
+        fi
+    else
+        if [ "$rc" -ne 0 ]; then
+            echo "  FALSE POSITIVE: $desc"
+            printf '%s\n' "$out" | sed 's/^/      /' | head -4
+            fails=$((fails + 1))
+        else
+            echo "  ok: $desc"
+        fi
+    fi
+}
+
+echo "== rejects what it must reject =="
+
+run_probe main/probe_ctl.c 'void f(void){ esp_wifi_start(); }
+' fail "plain SAR-ADC contender (positive control: if this passes, nothing below means anything)"
+
+# The bypass this file was written for.
+run_probe main/probe_splice.c 'void f(void){ adc_oneshot\
+_new_unit(); }
+' fail "identifier split by a line continuation"
+
+run_probe main/probe_splice3.c 'void f(void){ esp_\
+wifi_\
+start(); }
+' fail "identifier split across three lines"
+
+run_probe main/probe_disable.c 'void f(void){ bootloader_random_disable(); }
+' fail "bootloader_random_disable, which returns the RNG to pseudo-random"
+
+run_probe main/probe_rawdraw.c 'void f(void){ uint32_t x = esp_random(); }
+' fail "raw HWRNG draw outside main/hw_entropy.c"
+
+run_probe main/probe_libc.c 'void f(void){ int x = rand(); }
+' fail "libc PRNG"
+
+run_probe main/probe_i2s.c 'void f(void){ i2s_new_channel(0, 0, 0); }
+' fail "I2S, which contends for the SAR ADC"
+
+echo "== accepts what it must accept =="
+
+run_probe main/probe_clean.c 'void f(void){ int x = 1; (void)x; }
+' pass "ordinary code"
+
+run_probe main/probe_comment.c '/* esp_wifi_start() is named here in prose only */
+void f(void){ int x = 1; (void)x; }
+' pass "a banned token inside a comment is not code"
+
+run_probe main/probe_dead.c '#if 0
+void f(void){ esp_wifi_start(); }
+#endif
+' pass "a banned token inside #if 0 is not live code"
+
+echo
+if [ "$fails" -ne 0 ]; then
+    echo "FAIL: $fails case(s) did not behave as required"
+    exit 1
+fi
+echo "OK: check-rng-hygiene.sh rejects every known bypass and accepts sanctioned use"


### PR DESCRIPTION
## Summary

A backslash-newline inside an identifier walked straight past the scanner. Splices continuations before matching, and adds `scripts/test-rng-hygiene.sh` so the rules are asserted rather than assumed.

## The bypass

```c
void f(void){ adc_oneshot\
_new_unit(); }
```

That is legal C. Translation phase 2 removes the backslash-newline before tokenization, so the compiler sees `adc_oneshot_new_unit()` while the guard, matching per physical line, sees `adc_oneshot\` and `_new_unit();` and matches neither.

Verified against a positive control that does fail:

| probe | before | after |
|---|---|---|
| `esp_wifi_start();` (control) | caught | caught |
| identifier split by a continuation | **passed** | caught |
| identifier split across three lines | **passed** | caught |

## Why this rule in particular

It defeats rule 5, the one forbidding anything that contends for the SAR ADC. That rule is the enforcement behind the v0.2.1 entropy fix: `bootloader_random_enable()` shares the SAR ADC, so a driver taking it back silently returns the device to the pseudo-random state that shipped in v0.1.0 through v0.2.0, with every health indicator still green. The whole point of that release was that the failure is invisible from the output, which is why the guard has to be the thing that catches it.

Macro aliasing was tested too and is **not** a bypass: `#define WIFI_UP esp_wifi_start` puts the banned token on the `#define` line, which the scanner catches. Only the splice got through.

## Findings still point at the right line

Splicing shifts `FNR`, so the finding is reported against `startline`, the first physical line of the spliced group. Confirmed: the two-line probe reports `:2` where the identifier begins, the three-line probe reports `:1`.

## The self-test

Ported from the pattern added in keep-node, including the two things that made it trustworthy there:

- every reject case requires the guard to **name the probe file**, so a guard aborting for an unrelated reason is reported as `WRONG REASON` instead of being credited as a detection
- the harness aborts if fewer than 10 files stage, so "scanned almost nothing" cannot look like a pass

Ten cases: seven rejections including both splice forms, `bootloader_random_disable`, a raw draw outside `main/hw_entropy.c`, libc PRNG and I2S contention; three acceptances covering ordinary code, a banned token in a comment, and one inside `#if 0`.

Probes stage into a throwaway `GIT_INDEX_FILE`, so the real index is untouched. The file does exist on disk while the guard runs, because the scanner reads bytes, and is removed on every path including the EXIT trap.

## Test plan

- [x] Both splice forms now caught; clean tree still passes
- [x] Self-test 10/10 on the fixed guard
- [x] **Regression control**: against the pre-fix guard it reports 2 BYPASS and exits 1, so it detects the defect rather than passing regardless
- [x] Line numbers verified to point at the first physical line of a spliced group
- [x] `bash -n` clean on both scripts, workflow parses, dependency-pin guard still passes
- [ ] CI

Not claimed: this closes a known evasion, it does not make a line-oriented scanner undefeatable. What changed is that this route is closed and every known route is now asserted on each run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RNG hygiene diagnostics for code split across continued lines, reporting the starting line accurately.

* **Tests**
  * Added comprehensive self-tests covering prohibited randomness patterns, comments, disabled code, and valid code.

* **Chores**
  * Integrated RNG hygiene self-tests into the automated validation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->