### PR TITLE
Fail loudly when a probe is not staged

### DIFF
--- a/scripts/test-rng-hygiene.sh
+++ b/scripts/test-rng-hygiene.sh
@@ -49,6 +49,23 @@ run_probe() {
         fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
     fi
 
+    # Both that the tree is populated AND that this probe is in it. The git
+
+    # errors above are discarded, so a failed `git add` would otherwise leave
+
+    # the guard scanning a probe-free tree and the case judged on a file it
+
+    # never saw.
+
+    if ! GIT_INDEX_FILE="$TMPD/index" git ls-files --error-unmatch "$name" >/dev/null 2>&1; then
+
+        echo "  HARNESS BROKEN: $name was not staged; the guard would never see it"
+
+        fails=$((fails + 1)); rm -f "$name"; PROBE=""; return
+
+    fi
+
+
     local rc=0 out
     out=$(GIT_INDEX_FILE="$TMPD/index" "$GUARD" 2>&1) || rc=$?
     rm -f "$name"; PROBE=""


### PR DESCRIPTION
## Summary

Backports the probe-staged assertion from privkeyio/keep-android#473 and privkeyio/keep#936, so the four copies of this harness do not diverge.

## The gap

`run_probe` discards the errors from `git read-tree` and `git add`. The existing `staged -lt 10` check does not cover a failed `git add`: HEAD's whole tree is still in the index, so the count sails past 10 while the probe itself is missing, and the guard is then judged on a file it never received.

A reject case surfaces that as a spurious `BYPASS`, which sends someone hunting a guard defect that does not exist. An accept case surfaces it as a silent pass.

Now asserted directly:

```sh
if ! GIT_INDEX_FILE="$TMPD/index" git ls-files --error-unmatch "$name" >/dev/null 2>&1; then
    echo "  HARNESS BROKEN: $name was not staged; the guard would never see it"
```

## Test plan

- [x] Self-test passes unchanged on the current guard
- [x] **Sabotage control**: replacing the `git add` with a no-op makes every case report `HARNESS BROKEN`, with zero `BYPASS` lines. Before this change the same sabotage produced `BYPASS`, the misleading result
- [x] Restored afterwards and passing
- [ ] CI

Worth recording how this landed: the first attempt at this backport spliced the block into the middle of an echo string, because the insertion anchored on `fi` and matched the `fi` inside the word `file(s)`. The corrupted file still parsed under `bash -n` and the self-test still reported OK, so "it passes" was true and meaningless. The sabotage control is what caught it. Re-anchored on `local rc=0 out`, which appears once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test harness validation to ensure temporary checks are correctly staged before evaluation.
  * Added clearer error handling and cleanup when staging fails or required test data is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->