### PR TITLE
Distinguish a pin ahead of a release from one behind it

### DIFF
--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -108,10 +108,32 @@ else
       tag_commit=$(git ls-remote "$url" "refs/tags/$latest_tag^{}" 2>/dev/null | cut -f1)
       [ -z "$tag_commit" ] && tag_commit=$(git ls-remote "$url" "refs/tags/$latest_tag" 2>/dev/null | cut -f1)
       if [ -n "$tag_commit" ] && [ "$tag_commit" != "$pin" ]; then
-        msg="$repo is pinned to ${pin:0:8} but upstream's newest release is $latest_tag (${tag_commit:0:8})"
-        if [ "$STRICT" -eq 1 ]; then fail "$msg"; else warn "$msg"; fi
-        echo "  → review the changelog before bumping; these are consumed by a signer's"
-        echo "    untrusted-input paths, so a 'patch' release can still be security-relevant."
+        # Differing from the newest release is not the same as being behind it.
+        # A pin deliberately ahead of a tag is the normal case here: libnostr-c
+        # v0.2.0 predates the ESP RNG fix, so keep-esp32 pins past it on purpose.
+        # Reporting that as stale is a false alarm that trains people to ignore
+        # this job. Ask GitHub which direction the difference runs.
+        # $repo is already owner/name; deriving it back out of $url was how the
+        # first attempt at this failed, by swallowing the .git suffix.
+        direction=""
+        if command -v gh >/dev/null 2>&1; then
+          direction=$(gh api "repos/$repo/compare/${tag_commit}...${pin}" --jq .status 2>/dev/null | head -1)
+          case "$direction" in ahead|behind|identical|diverged) ;; *) direction="" ;; esac
+        fi
+        case "$direction" in
+          ahead|identical)
+            # Ahead of the newest release, which is the intended state. Say so
+            # rather than staying silent, so the pin's position stays visible.
+            echo "  ok  $repo is pinned ahead of $latest_tag (${pin:0:8}), not behind it"
+            ;;
+          *)
+            msg="$repo is pinned to ${pin:0:8} but upstream's newest release is $latest_tag (${tag_commit:0:8})"
+            [ -n "$direction" ] && msg="$msg [$direction]"
+            if [ "$STRICT" -eq 1 ]; then fail "$msg"; else warn "$msg"; fi
+            echo "  → review the changelog before bumping; these are consumed by a signer's"
+            echo "    untrusted-input paths, so a 'patch' release can still be security-relevant."
+            ;;
+        esac
       fi
     else
       # Fork with no releases: the useful signal is the tip of the branch it was cut from.

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -121,10 +121,16 @@ else
           case "$direction" in ahead|behind|identical|diverged) ;; *) direction="" ;; esac
         fi
         case "$direction" in
-          ahead|identical)
+          ahead)
             # Ahead of the newest release, which is the intended state. Say so
             # rather than staying silent, so the pin's position stays visible.
             echo "  ok  $repo is pinned ahead of $latest_tag (${pin:0:8}), not behind it"
+            ;;
+          identical)
+            # Only reachable if the tag and the pin name the same commit through
+            # different refs, since the enclosing test already excluded an exact
+            # string match. Reported accurately rather than as "ahead".
+            echo "  ok  $repo is pinned at $latest_tag (${pin:0:8})"
             ;;
           *)
             msg="$repo is pinned to ${pin:0:8} but upstream's newest release is $latest_tag (${tag_commit:0:8})"


### PR DESCRIPTION
## Summary

The scheduled Dependency Pins job is failing on `main`. The freshness rule treats any difference from upstream's newest release as staleness, including being deliberately **ahead** of it.

## The false alarm

```
FAIL privkeyio/libnostr-c is pinned to 205aaf5a but upstream's newest release is v0.2.0 (0343224a)
```

That pin is ahead of `v0.2.0` by 4 commits and behind by 0. It is ahead on purpose: `v0.2.0` predates the ESP RNG fix, which is exactly why #151 pinned past the tag rather than to it. I noted the WARN at the time and said freshness only hard-fails under `--strict` on the schedule. It does, and this is that failure.

A guard that cries stale when a pin is deliberately ahead is worse than no guard, because it teaches people to skip the job.

## Fix

When the pin differs from the newest release, ask GitHub which direction:

```sh
gh api repos//compare/${tag_commit}...${pin} --jq .status
```

`ahead` or `identical` reports `ok` and passes. `behind`, `diverged`, or no answer at all keeps the original finding, with the direction appended when known. If `gh` is unavailable the behaviour is unchanged, so the rule never becomes weaker than it was.

Reporting `ok` rather than staying silent keeps the pin's position visible: "ahead of v0.2.0, not behind it" is the fact a reviewer wants.

## Test plan

- [x] Ancestry confirmed independently: `compare/0343224a...205aaf5a` gives `status: ahead, ahead_by: 4, behind_by: 0`
- [x] Non-strict: reports `ok  privkeyio/libnostr-c is pinned ahead of v0.2.0`
- [x] **Strict, which is what the scheduled run uses: exit 0**, where it was exit 1
- [x] **Negative control**: rolled every libnostr-c pin back to `724868d` (v0.1.5, genuinely behind v0.2.0). Strict reports `FAIL ... [behind]` and exits 1. Restored afterwards
- [x] Agreement rule untouched: all pins still verified identical across the Dockerfile and both workflows
- [ ] CI

My first attempt derived `owner/name` back out of the clone URL and swallowed the `.git` suffix, so every compare 404'd and silently fell through to the old behaviour. `$repo` already holds `owner/name`. The response is also validated against the four statuses the API can return, so a future error body cannot be mistaken for a direction.

## Separately

The pin is 6 commits behind libnostr-c `main`, which now carries the NIP-17 fail-closed fix and the QEMU smoke test. Whether to bump is a real decision rather than a CI failure, and worth weighing against keep-esp32-hq-7ol: the firmware links zero noscrypt symbols and only two libnostr-c symbols today, so the pin protects very little on that device until the coordinator is wired up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency freshness checks to more accurately identify whether pinned versions match, exceed, trail, or diverge from the latest upstream release.
  * Pins that are current or ahead of the latest release are now accepted without warnings.
  * Warnings and strict-mode failures now provide clearer status information for outdated or divergent pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->