### PR TITLE
Give the drift job a token and stop hiding why the compare failed

### DIFF
--- a/.github/workflows/dependency-pins.yml
+++ b/.github/workflows/dependency-pins.yml
@@ -54,4 +54,10 @@ jobs:
           # which would leave it readable by PR-authored code. Nothing here needs
           # git credentials.
           persist-credentials: false
+      # gh needs a token inside Actions; without one the compare call that
+      # decides whether a pin is ahead of or behind a release fails, and the
+      # rule falls back to reporting any difference as staleness. The
+      # workflow-level `contents: read` is all it needs for a public repo.
       - run: ./scripts/check-dependency-pins.sh --strict
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -115,10 +115,23 @@ else
         # this job. Ask GitHub which direction the difference runs.
         # $repo is already owner/name; deriving it back out of $url was how the
         # first attempt at this failed, by swallowing the .git suffix.
-        direction=""
+        direction=""; cmp_err=""
         if command -v gh >/dev/null 2>&1; then
-          direction=$(gh api "repos/$repo/compare/${tag_commit}...${pin}" --jq .status 2>/dev/null | head -1)
-          case "$direction" in ahead|behind|identical|diverged) ;; *) direction="" ;; esac
+          # stderr is kept. Discarding it once already turned "gh has no token"
+          # into an indistinguishable "pin looks stale", which cost a debugging
+          # cycle against CI.
+          cmp_out=$(gh api "repos/$repo/compare/${tag_commit}...${pin}" --jq .status 2>&1)
+          direction=$(printf '%s' "$cmp_out" | head -1)
+          case "$direction" in
+            ahead|behind|identical|diverged) ;;
+            *) cmp_err="$direction"; direction="" ;;
+          esac
+        else
+          cmp_err="gh not installed"
+        fi
+        if [ -z "$direction" ] && [ -n "$cmp_err" ]; then
+          echo "  note: could not determine direction vs $latest_tag: $cmp_err"
+          echo "        (falling back to reporting any difference as drift)"
         fi
         case "$direction" in
           ahead)


### PR DESCRIPTION
## Summary

#156 made the freshness rule direction-aware, and it still failed on `main`. Two causes, one of them mine twice over.

## What happened

Dispatching the workflow manually against `main` after #156 merged, which is the only way to exercise this job since it is gated on `schedule || workflow_dispatch` and shows `skipping` on every PR:

```
FAIL privkeyio/libnostr-c is pinned to 205aaf5a but upstream's newest release is v0.2.0 (0343224a)
```

No `[direction]` suffix, which meant the compare call returned nothing. **`gh` needs a token inside Actions**, and the step had none, so every call failed and the rule fell back to reporting any difference as drift. Exactly the fallback path I described in #156 as the thing that would make a broken `gh` look identical to a genuinely stale pin.

The log said nothing about why, because the script redirected `gh`'s stderr to `/dev/null`. The message was there the whole time:

```
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
```

## Fixes

**`GH_TOKEN: ${{ github.token }}` on the drift step.** The workflow already declares `permissions: contents: read`, which is all the compare endpoint needs for a public repository.

**stderr is kept.** When the direction cannot be determined the script now prints the reason and says it is falling back, so the next occurrence is diagnosable from the log instead of requiring a local reproduction.

## Test plan

- [x] With `gh` working: `ok  privkeyio/libnostr-c is pinned ahead of v0.2.0`, strict exits 0
- [x] **Control reproducing the CI condition**: shadowed `gh` with a stub that exits 4 and prints the real Actions message. The script now reports `note: could not determine direction vs v0.2.0: gh: To use GitHub CLI...` followed by `(falling back to reporting any difference as drift)`, then the original FAIL. Exit 1, and the cause is visible
- [x] Fallback behaviour unchanged when the direction is unknown, so the rule is never weaker than before the change
- [x] YAML parses; the drift step's env resolves to `GH_TOKEN`
- [ ] **Verification is a manual dispatch against `main` after merge**, not this PR's CI. The drift job does not run on pull requests, so green here proves nothing about the job that was failing

Third time in this session I have hidden the output of the command that was failing, after the same mistake in libnostr-c#67 twice. Noting it because the fix each time was identical: stop discarding it.