### PR TITLE
Bump ESP-IDF to v5.4.4 everywhere and guard against partial bumps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1.2.0
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.4
           target: esp32s3
           path: keep-esp32
 

--- a/.github/workflows/dependency-pins.yml
+++ b/.github/workflows/dependency-pins.yml
@@ -40,6 +40,10 @@ jobs:
           # git credentials.
           persist-credentials: false
       - run: ./scripts/check-dependency-pins.sh
+      # A guard nobody tests is a guard that quietly stops guarding. This asserts
+      # it still rejects a partial ESP-IDF bump, which is the one diff shape
+      # dependabot can produce and every other check calls clean.
+      - run: ./scripts/test-dependency-pins.sh
 
   drift:
     name: Pins are current with upstream

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Build ESP32-S3 firmware
         uses: espressif/esp-idf-ci-action@9d38657f3d789ca759b2b37aaf5ceffbc42c4f0d # v1.2.0
         with:
-          esp_idf_version: v5.4.1
+          esp_idf_version: v5.4.4
           target: esp32s3
           path: keep-esp32
 

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: © 2026 PrivKey LLC
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-FROM espressif/idf:v5.4.1@sha256:6b4adab7b282e9261a154d7130fb4945a3c28bd35c2e914357c2f522643cb92a AS builder
+FROM espressif/idf:v5.4.4@sha256:9ce51d4ace496845678065dc86f8e55fb9c25fc9f01f45597042afa7ed546926 AS builder
 
 ARG SOURCE_DATE_EPOCH=0
 ENV SOURCE_DATE_EPOCH=${SOURCE_DATE_EPOCH}

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -150,7 +150,7 @@ dependencies:
   idf:
     source:
       type: idf
-    version: 5.4.1
+    version: 5.4.4
   lvgl/lvgl:
     component_hash: 184e532558c1c45fefed631f3e235423d22582aafb4630f3e8885c35281a49ae
     dependencies: []

--- a/docs/REPRODUCIBILITY.md
+++ b/docs/REPRODUCIBILITY.md
@@ -11,7 +11,7 @@ Reproducible builds allow anyone to verify that a binary was built from a specif
 
 | Component | Version |
 |-----------|---------|
-| Base Image | espressif/idf:v5.4.1 (pinned by SHA256 digest) |
+| Base Image | espressif/idf:v5.4.4 (pinned by SHA256 digest) |
 | Build Flags | `SOURCE_DATE_EPOCH=0`, ccache disabled |
 
 Dependencies are pinned to exact commit hashes in the Dockerfile.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -21,7 +21,7 @@
 
 ```bash
 mkdir -p ~/esp && cd ~/esp
-git clone -b v5.4.1 --recursive https://github.com/espressif/esp-idf.git
+git clone -b v5.4.4 --recursive https://github.com/espressif/esp-idf.git
 cd esp-idf && ./install.sh esp32s3
 source export.sh
 ```

--- a/scripts/check-dependency-pins.sh
+++ b/scripts/check-dependency-pins.sh
@@ -92,6 +92,42 @@ done <<EOF
 $docker_pins
 EOF
 
+# ------------------------------------------- 1b. ESP-IDF agreement ---------
+# The base image in the Dockerfile and esp_idf_version in the workflows must
+# name the same toolchain, for the same reason the dependency pins must: the
+# reproducible build is only meaningful if it builds what the release built.
+#
+# This rule exists because dependabot cannot get it right. It sees the FROM line
+# and nothing else; esp_idf_version is not an ecosystem it can parse. So every
+# IDF bump it opens moves the Dockerfile alone and leaves the workflows behind,
+# and until this check existed the whole suite went green on exactly that diff.
+idf_from=$(grep -oE '^FROM[[:space:]]+espressif/idf:v[0-9]+\.[0-9]+(\.[0-9]+)?@sha256:[a-f0-9]{64}' "$DOCKERFILE" | head -1)
+if [ -z "$idf_from" ]; then
+  fail "$DOCKERFILE has no digest-pinned espressif/idf base image."
+  echo "  → a bare tag is not a pin: image tags can be repushed, so the reproducible"
+  echo "    build could silently change toolchain. Use image:vX.Y.Z@sha256:<digest>."
+else
+  idf_docker_ver=${idf_from##*espressif/idf:}
+  idf_docker_ver=${idf_docker_ver%%@*}
+  for wf in $WORKFLOWS; do
+    wf_idf_all=$(grep -oE 'esp_idf_version:[[:space:]]*v?[0-9]+\.[0-9]+(\.[0-9]+)?' "$wf" \
+      | sed -E 's/.*esp_idf_version:[[:space:]]*//' | sort -u)
+    if [ -z "$wf_idf_all" ]; then
+      fail "$wf does not set esp_idf_version, but $DOCKERFILE pins the toolchain to $idf_docker_ver."
+      continue
+    fi
+    for wf_idf in $wf_idf_all; do
+      if [ "$wf_idf" != "$idf_docker_ver" ]; then
+        fail "ESP-IDF version disagrees between $DOCKERFILE and $wf:"
+        echo "    $DOCKERFILE: $idf_docker_ver"
+        echo "    $wf:        $wf_idf"
+        echo "  → the reproducible build and the released artifact would be built with"
+        echo "    different toolchains, so verifying a release against source would fail."
+      fi
+    done
+  done
+fi
+
 # ------------------------------------------------------- 2. freshness ------
 if ! git ls-remote --exit-code https://github.com/privkeyio/keep-esp32.git HEAD >/dev/null 2>&1; then
   echo

--- a/scripts/test-dependency-pins.sh
+++ b/scripts/test-dependency-pins.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# Self-test for check-dependency-pins.sh.
+#
+# The guard's whole value is failing on diffs that otherwise look clean, so each
+# case below is a diff that passed every other check in CI. The first is the
+# shape dependabot produces for an ESP-IDF bump: it can only edit the Dockerfile
+# FROM line, so the workflows stay behind and the reproducible build stops
+# matching the released artifact, with nothing red anywhere.
+#
+# Cases run against a throwaway copy of the tree, so the real working tree is
+# never modified. Freshness needs the network and is not what is under test, so
+# the copies run with an unreachable proxy: the guard's documented no-network
+# path skips freshness and still enforces agreement, which keeps this fast and
+# usable offline.
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || { echo "FAIL: cannot cd to the repo root"; exit 1; }
+GUARD=scripts/check-dependency-pins.sh
+[ -x "$GUARD" ] || { echo "FAIL: $GUARD not found or not executable"; exit 1; }
+
+TMPD=$(mktemp -d)
+trap 'rm -rf "$TMPD"' EXIT
+fails=0
+
+# Offline: forces the guard's no-network branch so only agreement is exercised.
+export https_proxy=http://127.0.0.1:1 http_proxy=http://127.0.0.1:1
+export GIT_TERMINAL_PROMPT=0
+
+# run_case <name> <pass|fail> <expected-substring-when-failing> <mutator...>
+run_case() {
+    local name="$1" expect="$2" want="$3"; shift 3
+    local work="$TMPD/$name"
+    rm -rf "$work"; mkdir -p "$work/scripts" "$work/.github/workflows"
+    cp Dockerfile.reproducible "$work/"
+    cp .github/workflows/ci.yml .github/workflows/release.yml "$work/.github/workflows/"
+    cp "$GUARD" "$work/scripts/"
+    ( cd "$work" && "$@" )
+
+    local rc=0 out
+    out=$( cd "$work" && ./scripts/check-dependency-pins.sh 2>&1 ) || rc=$?
+
+    if [ "$expect" = fail ]; then
+        if [ "$rc" -eq 0 ]; then
+            echo "  BYPASS: $name (guard passed a diff it must reject)"; fails=$((fails+1))
+        elif ! printf '%s' "$out" | grep -qF "$want"; then
+            echo "  WRONG REASON: $name (failed, but not for '$want')"
+            printf '%s\n' "$out" | grep -i fail | head -2 | sed 's/^/      /'
+            fails=$((fails+1))
+        else
+            echo "  ok: $name"
+        fi
+    else
+        if [ "$rc" -ne 0 ]; then
+            echo "  FALSE POSITIVE: $name"
+            printf '%s\n' "$out" | grep -i fail | head -3 | sed 's/^/      /'
+            fails=$((fails+1))
+        else
+            echo "  ok: $name"
+        fi
+    fi
+}
+
+echo "== accepts the tree as committed =="
+run_case baseline pass "" true
+
+echo "== rejects a partial ESP-IDF bump =="
+
+# Exactly what dependabot opens: Dockerfile moves, workflows do not.
+run_case idf-dockerfile-only fail "ESP-IDF version disagrees" \
+    sed -i -E 's|(espressif/idf:)v[0-9]+\.[0-9]+(\.[0-9]+)?|\1v9.9.9|' Dockerfile.reproducible
+
+# The mirror image: someone edits the workflows and forgets the image.
+run_case idf-workflow-only fail "ESP-IDF version disagrees" \
+    sed -i -E 's|(esp_idf_version:[[:space:]]*)v?[0-9]+\.[0-9]+(\.[0-9]+)?|\1v9.9.9|' .github/workflows/ci.yml
+
+# A tag with no digest is not a pin: tags can be repushed.
+run_case idf-tag-not-digest fail "no digest-pinned espressif/idf" \
+    sed -i -E 's|(FROM[[:space:]]+espressif/idf:v[0-9]+\.[0-9]+(\.[0-9]+)?)@sha256:[a-f0-9]{64}|\1|' Dockerfile.reproducible
+
+echo "== the pre-existing dependency rule still bites =="
+
+# Positive control for rule 1. If this stops failing, the scanner has gone
+# quiet and every case above would pass while detecting nothing.
+run_case dep-commit-disagree fail "disagrees between" \
+    sed -i -E '0,/ref: [a-f0-9]{40}/s//ref: 0000000000000000000000000000000000000000/' .github/workflows/ci.yml
+
+echo
+if [ "$fails" -ne 0 ]; then
+    echo "FAIL: $fails case(s) did not behave as required"
+    exit 1
+fi
+echo "OK: check-dependency-pins.sh rejects every known partial bump and accepts the committed tree"


### PR DESCRIPTION
Replaces the closed dependabot bump (#148), which moved `Dockerfile.reproducible` alone.

## Why not v6.0.2

ESP-IDF v6.0 ships Mbed TLS v4.0, where most legacy crypto APIs are removed in favor of PSA Crypto. This firmware calls `mbedtls_gcm_*`, `mbedtls_hkdf`, `mbedtls_md_hmac`, `mbedtls_pkcs5_pbkdf2_hmac_ext` and `mbedtls_sha256_*`; libnostr-c calls `mbedtls_ctr_drbg_*` and `mbedtls_entropy_*`. All of those are on the legacy side, so v6.0 is a cross-repo crypto migration rather than a version bump.

The blocking risk is storage compatibility: `derive_key()` in `storage_crypto.c` builds the share-encryption key with `mbedtls_hkdf`, so a PSA port must be proven byte-identical or existing devices cannot decrypt their stored shares. v6.0 also enables `MBEDTLS_THREADING_C` by default and switches the default libc from Newlib to PicolibC.

None of that is forced right now. The 5.4 line is still receiving fixes, and v5.4.4 is a patch release on the version already in use. v6.0 is worth planning separately, with the derivation compatibility proof as its first deliverable.

## What changed

`v5.4.1` appeared in six places. All six move together:

| location | change |
| --- | --- |
| `Dockerfile.reproducible` | base image to `v5.4.4`, digest re-pinned |
| `.github/workflows/ci.yml` | `esp_idf_version` |
| `.github/workflows/release.yml` | `esp_idf_version` |
| `docs/REPRODUCIBILITY.md` | documented base image |
| `docs/USAGE.md` | clone instructions |
| `dependencies.lock` | recorded IDF version |

The new digest was resolved from the registry, and the method was validated by confirming it returns the exact digest currently pinned for `v5.4.1`.

`dependencies.lock` records the IDF version and is rewritten by the build. CI already fails when a build re-resolves that lock, so leaving it behind would have turned this PR red: a sixth location that only surfaced by building rather than by grepping.

## Closing the gap that let a partial bump look clean

`scripts/check-dependency-pins.sh` enforced agreement for the four source dependencies but never looked at the ESP-IDF image, so a Dockerfile-only bump passed every check including the pin guard itself. Dependabot cannot produce any other shape here: it sees the `FROM` line, and `esp_idf_version` is not an ecosystem it can parse.

This adds an ESP-IDF agreement rule covering both directions of disagreement, and rejects a base image pinned by bare tag instead of digest.

`scripts/test-dependency-pins.sh` is new and wired into CI, following the pattern already used for the RNG guard. It asserts the guard rejects a Dockerfile-only bump, a workflow-only bump, and a digest-less image, and retains a positive control on the pre-existing dependency rule so a scanner that stops scanning cannot pass. Verified by removing the new rule and confirming exactly the three expected cases fail, then restoring it.

## Verification

Built from clean on v5.4.4 and flashed to an M5Stack CoreS3. The device reports:

```
version: 0.2.1
rng_entropy_source: true
rng_healthy: true
rng_failed_checks: 0
self_test_passed: 4
self_test_failed: 0
```

`rng_entropy_source` is the one that mattered: it confirms the v0.2.1 entropy fix still holds on the new toolchain rather than regressing silently.
