### PR TITLE
Release v0.2.2

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Keep FROST Signer",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "builds": [
     {
       "chipFamily": "ESP32-S3",

--- a/main/main.c
+++ b/main/main.c
@@ -25,7 +25,7 @@
 #include "self_test.h"
 
 #define TAG                  "main"
-#define VERSION              "0.2.1"
+#define VERSION              "0.2.2"
 #define RATE_LIMIT_THRESHOLD 5
 #define RATE_LIMIT_DELAY_MS  1000
 


### PR DESCRIPTION
Version bump for v0.2.2. No firmware source changes; the release exists to ship dependency updates that have accumulated on main since v0.2.1.

Every upstream component moved, so the shipped binary differs from v0.2.1 in ways that matter:

| dependency | v0.2.1 | v0.2.2 |
| --- | --- | --- |
| libwally-core | release_1.5.1 | release_1.5.6 |
| libnostr-c | `4e8d01b` | `205aaf5` |
| secp256k1-frost | `832bac2` | `746dbbe` |
| ESP-IDF | v5.4.1 | v5.4.4 |

Two of those carry fixes users should have. libwally-core was five security releases behind at the point v0.2.1 shipped, which is the gap `scripts/check-dependency-pins.sh` was written to catch. The libnostr-c range includes hardening against JSON injection, memory safety and crypto wiping issues, and a change letting the ESP32 RNG report failure the way every other backend does.

`PROTOCOL_VERSION` stays at 0.2.0: the wire protocol is unchanged.

Built and flashed to an M5Stack CoreS3 before tagging. The device reports:

```
version: 0.2.2
rng_entropy_source: true
rng_healthy: true
rng_failed_checks: 0
self_test_passed: 4
self_test_failed: 0
```

The release workflow packages whatever is at the tag and has no version gate, so the bump lands here first and is confirmed on hardware rather than assumed.
