### PR TITLE
Run every native test CI builds, and fail when one cannot be built

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,37 @@ jobs:
           ./configure --disable-elements --disable-tests
           make -j$(nproc)
 
+      - name: Install cJSON for the native tests
+        # cJSON normally comes from managed_components/, which the IDF component
+        # manager generates and .gitignore excludes. This job never runs an IDF
+        # build, so that directory does not exist here and every cJSON-gated test
+        # configured itself away silently.
+        run: sudo apt-get update && sudo apt-get install -y libcjson-dev
+
       - name: Run native tests
         run: |
           cd keep-esp32/test/native
           mkdir -p build && cd build
-          cmake ..
+          # REQUIRE_ALL_TESTS turns a missing optional dependency into a configure
+          # error. Without it a dependency that quietly disappears takes its tests
+          # with it and the job still reports success.
+          cmake .. -DREQUIRE_ALL_TESTS=ON
           make
-          ./test_frost
-          ./test_frost_signer_core
-          ./test_session
-          ./test_storage
-          ./test_secure_element
-          [ ! -f ./test_protocol ] || ./test_protocol
-          [ ! -f ./test_psbt_fraud_integration ] || ./test_psbt_fraud_integration
-          [ ! -f ./test_pin_attempt_limit ] || ./test_pin_attempt_limit
+          # Run everything that was built, rather than a hand-maintained list.
+          # The list had drifted: 14 binaries were compiled and 5 were executed,
+          # and three of the names in it did not exist, guarded by `[ ! -f ]` so
+          # their absence read as success.
+          failed=""
+          for t in ./test_*; do
+            [ -f "$t" ] && [ -x "$t" ] || continue
+            echo "== $t"
+            "$t" || failed="$failed $t"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::failing native tests:$failed"
+            exit 1
+          fi
+          echo "All native tests passed.
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
             echo "::error::failing native tests:$failed"
             exit 1
           fi
-          echo "All native tests passed.
+          echo "All native tests passed."
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
 
+# No job here uses GITHUB_TOKEN: the checkouts are public and nothing calls the
+# API, so a read-only token is all any of them needs. Set at workflow level so a
+# new job cannot inherit the repository default by omission.
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]

--- a/test/native/CMakeLists.txt
+++ b/test/native/CMakeLists.txt
@@ -8,7 +8,50 @@ endif()
 set(CMAKE_C_STANDARD 99)
 
 set(SECP_DIR ${CMAKE_CURRENT_LIST_DIR}/../../../secp256k1-frost)
+# cJSON comes from managed_components/, which the IDF component manager generates
+# and .gitignore excludes. A fresh checkout therefore does not have it, so every
+# test gated on it configured itself away with a STATUS message and CI reported
+# success having built neither test_protocol, test_coordinator, nor
+# test_coordinator_race. Nothing was red; three suites simply did not exist.
+#
+# Prefer the vendored copy when a build has produced it, so tests compile the
+# same cJSON the firmware does. Otherwise fall back to a system cJSON, which is
+# what a bare checkout has. REQUIRE_ALL_TESTS turns "not found" into a hard
+# configure error, and CI sets it: local developers may still skip, CI may not.
+option(REQUIRE_ALL_TESTS "Fail configuration when an optional test cannot be built" OFF)
+
 set(CJSON_DIR ${CMAKE_CURRENT_LIST_DIR}/../../managed_components/espressif__cjson/cJSON)
+if(EXISTS ${CJSON_DIR}/cJSON.c)
+    set(CJSON_AVAILABLE TRUE)
+    set(CJSON_SOURCES ${CJSON_DIR}/cJSON.c)
+    set(CJSON_INCLUDE ${CJSON_DIR})
+    set(CJSON_LIBS "")
+    message(STATUS "cJSON: vendored (managed_components)")
+else()
+    find_path(SYS_CJSON_INCLUDE_DIR cjson/cJSON.h)
+    find_library(SYS_CJSON_LIBRARY cjson)
+    if(SYS_CJSON_INCLUDE_DIR AND SYS_CJSON_LIBRARY)
+        set(CJSON_AVAILABLE TRUE)
+        set(CJSON_SOURCES "")
+        # The sources include "cJSON.h", not <cjson/cJSON.h>.
+        set(CJSON_INCLUDE ${SYS_CJSON_INCLUDE_DIR}/cjson)
+        set(CJSON_LIBS ${SYS_CJSON_LIBRARY})
+        message(STATUS "cJSON: system (${SYS_CJSON_LIBRARY})")
+    else()
+        set(CJSON_AVAILABLE FALSE)
+        set(CJSON_SOURCES "")
+        set(CJSON_INCLUDE "")
+        set(CJSON_LIBS "")
+    endif()
+endif()
+
+if(NOT CJSON_AVAILABLE AND REQUIRE_ALL_TESTS)
+    message(FATAL_ERROR
+        "cJSON not found, and REQUIRE_ALL_TESTS is ON. test_protocol, "
+        "test_integration_full, test_coordinator and test_coordinator_race "
+        "would be skipped. Install libcjson-dev, or run an IDF build first to "
+        "populate managed_components/.")
+endif()
 set(MAIN_DIR ${CMAKE_CURRENT_LIST_DIR}/../../main)
 
 add_executable(test_frost test_frost.c)
@@ -20,11 +63,12 @@ set_target_properties(test_frost PROPERTIES
     INSTALL_RPATH ${SECP_DIR}/build/src
 )
 
-if(EXISTS ${CJSON_DIR}/cJSON.c)
-    add_executable(test_protocol test_protocol.c ${CJSON_DIR}/cJSON.c ${MAIN_DIR}/protocol.c ${MAIN_DIR}/error_context.c ${MAIN_DIR}/error_codes.c)
+if(CJSON_AVAILABLE)
+    add_executable(test_protocol test_protocol.c ${CJSON_SOURCES} ${MAIN_DIR}/protocol.c ${MAIN_DIR}/error_context.c ${MAIN_DIR}/error_codes.c)
+    target_link_libraries(test_protocol ${CJSON_LIBS})
     target_include_directories(test_protocol PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks
-        ${CJSON_DIR}
+        ${CJSON_INCLUDE}
         ${MAIN_DIR}
     )
     target_compile_definitions(test_protocol PRIVATE
@@ -85,12 +129,13 @@ target_include_directories(test_integration PRIVATE
 )
 target_compile_definitions(test_integration PRIVATE NATIVE_TEST=1)
 
-if(EXISTS ${CJSON_DIR}/cJSON.c)
-    add_executable(test_integration_full test_integration.c ${CJSON_DIR}/cJSON.c ${MAIN_DIR}/error_codes.c)
+if(CJSON_AVAILABLE)
+    add_executable(test_integration_full test_integration.c ${CJSON_SOURCES} ${MAIN_DIR}/error_codes.c)
+    target_link_libraries(test_integration_full ${CJSON_LIBS})
     target_include_directories(test_integration_full PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks
         ${MAIN_DIR}
-        ${CJSON_DIR}
+        ${CJSON_INCLUDE}
     )
     target_compile_definitions(test_integration_full PRIVATE NATIVE_TEST=1 HAS_CJSON=1)
 endif()
@@ -174,7 +219,7 @@ target_include_directories(test_anti_glitch PRIVATE
 )
 target_compile_definitions(test_anti_glitch PRIVATE NATIVE_TEST=1)
 
-if(EXISTS ${CJSON_DIR}/cJSON.c)
+if(CJSON_AVAILABLE)
     add_executable(test_coordinator
         test_coordinator.c
         ${MAIN_DIR}/frost_coordinator.c
@@ -182,7 +227,7 @@ if(EXISTS ${CJSON_DIR}/cJSON.c)
         ${MAIN_DIR}/hw_entropy.c
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/ws_transport_mock.c
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/nostr_frost_stubs.c
-        ${CJSON_DIR}/cJSON.c
+        ${CJSON_SOURCES}
     )
         # main/ before mocks/: mocks/random_utils.h otherwise shadows the real header for
     # TUs that include it from test/native/, and its static inline rng_* bind ahead of
@@ -191,16 +236,16 @@ target_include_directories(test_coordinator PRIVATE
         ${MAIN_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CJSON_DIR}
+        ${CJSON_INCLUDE}
     )
     target_compile_definitions(test_coordinator PRIVATE NATIVE_TEST=1)
     find_package(Threads REQUIRED)
-    target_link_libraries(test_coordinator Threads::Threads)
+    target_link_libraries(test_coordinator Threads::Threads ${CJSON_LIBS})
 else()
     message(STATUS "Skipping test_coordinator (cJSON not found)")
 endif()
 
-if(EXISTS ${CJSON_DIR}/cJSON.c)
+if(CJSON_AVAILABLE)
     add_executable(test_coordinator_race
         test_coordinator_race.c
         ${MAIN_DIR}/frost_coordinator.c
@@ -208,7 +253,7 @@ if(EXISTS ${CJSON_DIR}/cJSON.c)
         ${MAIN_DIR}/hw_entropy.c
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/ws_transport_mock.c
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks/nostr_frost_stubs.c
-        ${CJSON_DIR}/cJSON.c
+        ${CJSON_SOURCES}
     )
         # main/ before mocks/: mocks/random_utils.h otherwise shadows the real header for
     # TUs that include it from test/native/, and its static inline rng_* bind ahead of
@@ -217,12 +262,12 @@ target_include_directories(test_coordinator_race PRIVATE
         ${MAIN_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/mocks
         ${CMAKE_CURRENT_SOURCE_DIR}
-        ${CJSON_DIR}
+        ${CJSON_INCLUDE}
     )
     target_compile_definitions(test_coordinator_race PRIVATE NATIVE_TEST=1)
     set_target_properties(test_coordinator_race PROPERTIES C_STANDARD 11)
     find_package(Threads REQUIRED)
-    target_link_libraries(test_coordinator_race Threads::Threads)
+    target_link_libraries(test_coordinator_race Threads::Threads ${CJSON_LIBS})
 
     include(CheckCCompilerFlag)
     check_c_compiler_flag(-fsanitize=thread HAVE_TSAN)


### PR DESCRIPTION
The native test job compiled 14 test binaries and executed 5. Three more were never built at all. Every check was green throughout.

## What was not running

`test_protocol`, `test_coordinator` and `test_coordinator_race` are gated on `${CJSON_DIR}/cJSON.c`, which lives under `managed_components/`. That directory is generated by the IDF component manager and excluded by `.gitignore`, and this job never runs an IDF build, so the path is absent on a fresh checkout. CMake configured those targets away with a STATUS message, and the job then guarded the run with `[ ! -f ./test_protocol ] || ./test_protocol`, so a binary that was never built read as a pass. The CI log shows it plainly:

```
-- Skipping test_protocol (cJSON not found)
-- Skipping test_coordinator (cJSON not found)
```

A further seven were compiled every run and never executed, because the list of tests to run was maintained by hand and had drifted from the list of tests that exist: `test_anti_glitch`, `test_hw_entropy`, `test_hw_entropy_sha`, `test_integration`, `test_psbt_fraud`, `test_secresult`, `test_self_test`.

`test_protocol` covers protocol parsing, which is a trust boundary on this device. `test_coordinator_race` is a ThreadSanitizer race test. `test_hw_entropy` and `test_self_test` cover the entropy path behind the v0.2.1 fix.

## Changes

cJSON discovery now prefers the vendored copy when a build has produced it, so tests compile the same cJSON as the firmware, and otherwise falls back to a system cJSON, which is what a bare checkout has. `REQUIRE_ALL_TESTS` turns "not found" into a configure error; CI sets it, so a dependency that quietly disappears fails the job instead of taking its tests with it. Local developers can still configure without it.

The job now runs every executable it built rather than a fixed list, so a new test is picked up by existing it, and collects failures instead of stopping at the first.

## Verification

Both discovery paths were exercised. With `managed_components/` present, configuration reports `cJSON: vendored`. With it moved aside, reproducing a fresh checkout, it reports `cJSON: system` and all four previously-skipped targets build and pass.

The full suite was built and run locally before changing the job, to confirm that enabling seven previously-unexecuted binaries would not turn CI red: 18 built, 18 passed, 0 failed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded native test execution to automatically run all built test programs and report failures consistently.
  * Improved handling of cJSON-dependent tests, supporting both bundled and system installations.
  * Added an option to require all tests and treat unavailable test dependencies as failures when enabled.

* **Chores**
  * Updated continuous integration setup to install required native testing dependencies and validate the complete test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->