### PR TITLE
Pin libnostr-c to v0.2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: privkeyio/libnostr-c
-          ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
+          ref: 361a4917d8179370bbd2ffcf6dcfa573de4fb97d # v0.2.1
           path: libnostr-c
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: privkeyio/libnostr-c
-          ref: 205aaf5ae849d6408dab41ca5be2abfc24801ad9 # main, post-v0.2.0 (ESP RNG fix)
+          ref: 361a4917d8179370bbd2ffcf6dcfa573de4fb97d # v0.2.1
           path: libnostr-c
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/Dockerfile.reproducible
+++ b/Dockerfile.reproducible
@@ -15,7 +15,7 @@ COPY . keep-esp32/
 
 RUN for repo in \
         "privkeyio/secp256k1-frost 746dbbea5c34dde963c9bd55bc7474b2d50fa597" \
-        "privkeyio/libnostr-c 205aaf5ae849d6408dab41ca5be2abfc24801ad9" \
+        "privkeyio/libnostr-c 361a4917d8179370bbd2ffcf6dcfa573de4fb97d" \
         "privkeyio/noscrypt 45fcbef32f958145d6797f384a225c0d43616886" \
         "ElementsProject/libwally-core 0c41f38fb1c201786e9c3ac9eae4f5f80c051399"; do \
         set -- $repo; \

--- a/dependencies.lock
+++ b/dependencies.lock
@@ -165,6 +165,6 @@ direct_dependencies:
 - espressif/esp_websocket_client
 - espressif/m5stack_core_s3
 - idf
-manifest_hash: f91c307533d08a2c00806e576fc7f20d242dab14b972db21047300e6cb04e49d
+manifest_hash: 4d5693bbcdcbdd24ebac5de684d4886c66a9abf320a9c5b3a45c6de8c9336424
 target: esp32s3
 version: 2.0.0


### PR DESCRIPTION
libnostr-c cut v0.2.1, so the pin here is now eight commits behind a release rather than ahead of one. The scheduled drift job reports it:

```
FAIL privkeyio/libnostr-c is pinned to 205aaf5a but upstream's newest release is v0.2.1 (361a4917) [behind]
```

Moves all three locations together, which the agreement rule requires: `Dockerfile.reproducible`, `ci.yml` and `release.yml`.

## No firmware release needed

`src/nip17.c` is the only shipped source that changed in that range, and this firmware does not use NIP-17. Everything else is CI, tests, docs and version manifests. v0.2.1 does carry a fail-closed fix for NIP-17 sealing on a failed RNG draw, which matters to library consumers but is not reachable from this image.

The two fixes that do matter here, the ESP32 RNG reporting failure and the FreeRTOS task-create fix, were already in the previous pin and shipped in v0.2.2.

## dependencies.lock

`components/libnostr-c` is a component directory, so libnostr-c's own `idf_component.yml` is part of the manifest hash recorded in `dependencies.lock`. v0.2.1 bumped that manifest from 0.2.0 to 0.2.1, so the hash moves with the pin and the lock has to move with it. Only `manifest_hash` changes; no component version is re-resolved.

The first push omitted it and the lock guard from #152 caught exactly that, which is the behavior it was added for. The committed lock is byte-identical to what CI computed, so `before` and `after` now agree.

## Verification

`./scripts/check-dependency-pins.sh --strict` passes after the change and failed before it. Built clean and flashed to an M5Stack CoreS3:

```
version: 0.2.2
rng_entropy_source: true
rng_healthy: true
rng_failed_checks: 0
self_test_passed: 4
self_test_failed: 0
```
